### PR TITLE
Alternative for set_block_type

### DIFF
--- a/docs/pyasdf/examples.rst
+++ b/docs/pyasdf/examples.rst
@@ -126,7 +126,7 @@ Saving inline arrays
 
 For these sort of small arrays, you may not care about the efficiency
 of a binary representation and want to just save the content directly
-in the YAML tree.  The `~pyasdf.AsdfFile.set_block_type` method
+in the YAML tree.  The `~pyasdf.AsdfFile.set_array_storage` method
 can be used to set the type of block of the associated data, either
 ``internal``, ``external`` or ``inline``.
 
@@ -146,7 +146,7 @@ can be used to set the type of block of the associated data, either
    my_array = np.random.rand(8, 8)
    tree = {'my_array': my_array}
    ff = AsdfFile(tree)
-   ff.set_block_type(my_array, 'inline')
+   ff.set_array_storage(my_array, 'inline')
    with ff.write_to("test.asdf"):
        pass
 
@@ -193,7 +193,7 @@ To save a block in an external file, set its block type to
    my_array = np.random.rand(8, 8)
    tree = {'my_array': my_array}
    ff = AsdfFile(tree)
-   ff.set_block_type(my_array, 'external')
+   ff.set_array_storage(my_array, 'external')
    with ff.write_to("test.asdf"):
        pass
 

--- a/pyasdf/asdf.py
+++ b/pyasdf/asdf.py
@@ -238,7 +238,7 @@ class AsdfFile(versioning.VersionedMixin):
         """
         return self._blocks
 
-    def set_block_type(self, arr, block_type):
+    def set_array_storage(self, arr, array_storage):
         """
         Set the block type to use for the given array data.
 
@@ -249,7 +249,7 @@ class AsdfFile(versioning.VersionedMixin):
             the tree, only the most recent block type setting will be
             used, since all views share a single block.
 
-        block_type : str
+        array_storage : str
             Must be one of:
 
             - ``internal``: The default.  The array data will be
@@ -260,9 +260,9 @@ class AsdfFile(versioning.VersionedMixin):
 
             - ``inline``: Store the data as YAML inline in the tree.
         """
-        self.blocks[arr].block_type = block_type
+        self.blocks[arr].array_storage = array_storage
 
-    def get_block_type(self, arr):
+    def get_array_storage(self, arr):
         """
         Get the block type for the given array data.
 
@@ -270,7 +270,7 @@ class AsdfFile(versioning.VersionedMixin):
         ----------
         arr : numpy.ndarray
         """
-        return self.blocks[arr].block_type
+        return self.blocks[arr].array_storage
 
     @classmethod
     def _parse_header_line(cls, line):

--- a/pyasdf/tags/core/ndarray.py
+++ b/pyasdf/tags/core/ndarray.py
@@ -300,12 +300,12 @@ class NDArrayType(AsdfType):
 
         result = {}
         result['shape'] = list(shape)
-        if block.block_type == 'streamed':
+        if block.array_storage == 'streamed':
             result['shape'][0] = '*'
 
         dtype, byteorder = numpy_dtype_to_asdf_dtype(dtype)
 
-        if block.block_type == 'inline':
+        if block.array_storage == 'inline':
             result['data'] = data.tolist()
             result['dtype'] = dtype
         else:

--- a/pyasdf/tags/core/tests/test_ndarray.py
+++ b/pyasdf/tags/core/tests/test_ndarray.py
@@ -183,7 +183,7 @@ def test_inline():
     buff = io.BytesIO()
 
     with asdf.AsdfFile(tree) as ff:
-        ff.blocks[tree['science_data']].block_type = 'inline'
+        ff.blocks[tree['science_data']].array_storage = 'inline'
         ff.write_to(buff)
 
     buff.seek(0)

--- a/pyasdf/tests/test_low_level.py
+++ b/pyasdf/tests/test_low_level.py
@@ -204,8 +204,8 @@ def test_external_block(tmpdir):
     my_array = np.random.rand(8, 8)
     tree = {'my_array': my_array}
     ff = asdf.AsdfFile(tree)
-    ff.set_block_type(my_array, 'external')
-    assert ff.get_block_type(my_array) == 'external'
+    ff.set_array_storage(my_array, 'external')
+    assert ff.get_array_storage(my_array) == 'external'
 
     with ff.write_to(os.path.join(tmpdir, "test.asdf")):
         pass

--- a/pyasdf/tests/test_stream.py
+++ b/pyasdf/tests/test_stream.py
@@ -149,7 +149,7 @@ def test_array_to_stream():
     buff = io.BytesIO()
 
     with asdf.AsdfFile(tree) as ff:
-        ff.blocks[tree['stream']].block_type = 'streamed'
+        ff.blocks[tree['stream']].array_storage = 'streamed'
         ff.write_to(buff)
         ff.write_to_stream(np.array([5, 6, 7, 8], np.int64).tostring())
 
@@ -171,7 +171,7 @@ def test_too_many_streams():
     buff = io.BytesIO()
 
     with asdf.AsdfFile(tree) as ff:
-        ff.blocks[tree['stream1']].block_type = 'streamed'
-        ff.blocks[tree['stream2']].block_type = 'streamed'
+        ff.blocks[tree['stream1']].array_storage = 'streamed'
+        ff.blocks[tree['stream2']].array_storage = 'streamed'
         with pytest.raises(ValueError):
             ff.write_to(buff)


### PR DESCRIPTION
I've never been entirely crazy about the name for the `set_block_type` method (though it could just be me).  I was instead thinking something along the lines of `set_array_storage`.  This has two advantages: The first is that the name makes clear that this associates some property with a specific _array_.  The other is that the nomenclature is confusing--in ASDF parlance a "block" is a specific physical storage format, but arrays don't _have_ to be in a block (`set_block_type` for example allows setting an inline array).  The the future we might support other types of storage as well (maybe?).  
