### PR TITLE
Make it easier to test on a devel asdf-standard

### DIFF
--- a/pyasdf/setup_package.py
+++ b/pyasdf/setup_package.py
@@ -7,8 +7,10 @@ import os
 
 
 def get_package_data():  # pragma: no cover
+    ASDF_STANDARD_ROOT = os.environ.get("ASDF_STANDARD_ROOT", "asdf-standard")
+
     schemas = []
-    root = "asdf-standard/schemas"
+    root = os.path.join(ASDF_STANDARD_ROOT, "schemas")
     for node, dirs, files in os.walk(root):
         for fname in files:
             if fname.endswith('.yaml'):
@@ -18,7 +20,7 @@ def get_package_data():  # pragma: no cover
                         root))
 
     reference_files = []
-    root = "asdf-standard/reference_files/0.1.0"
+    root = os.path.join(ASDF_STANDARD_ROOT, "reference_files", "0.1.0")
     for node, dirs, files in os.walk(root):
         for fname in files:
             if fname.endswith('.yaml') or fname.endswith('.asdf'):

--- a/pyasdf/tests/test_schema.py
+++ b/pyasdf/tests/test_schema.py
@@ -78,13 +78,18 @@ def test_all_schema_examples():
     # Make sure that the examples in the schema files (and thus the
     # ASDF standard document) are valid.
 
-    def test_example(example):
+    def test_example(args):
+        fname, example = args
         buff = helpers.yaml_to_asdf('example: ' + example.strip())
         with asdf.AsdfFile() as ff:
             # Add a dummy block so that the ndarray examples
             # work
             ff.blocks.add(block.Block(np.empty((1024))))
-            ff.read(buff)
+            try:
+                ff.read(buff)
+            except:
+                print("From file:", fname)
+                raise
 
     def find_examples_in_schema(path):
         with open(path, 'rb') as fd:
@@ -110,7 +115,7 @@ def test_all_schema_examples():
                 continue
             for example in find_examples_in_schema(
                     os.path.join(root, fname)):
-                yield test_example, example
+                yield test_example, (fname, example)
 
 
 def test_schema_caching():

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,9 @@ RELEASE = 'dev' not in VERSION
 if not RELEASE:
     VERSION += get_git_devstr(False)
 
+# Get root of asdf-standard documents
+ASDF_STANDARD_ROOT = os.environ.get('ASDF_STANDARD_ROOT', 'asdf-standard')
+
 # Populate the dict of setup command overrides; this should be done before
 # invoking any other functionality from distutils since it can potentially
 # modify distutils' behavior.
@@ -78,13 +81,14 @@ package_info = get_package_info()
 package_info['package_data'].setdefault(PACKAGENAME, []).append('data/*')
 
 # The schemas come from a git submodule, so we deal with them here
-schema_root = "asdf-standard/schemas"
+schema_root = os.path.join(ASDF_STANDARD_ROOT, "schemas")
 
 package_info['package_dir']['pyasdf.schemas'] = schema_root
 package_info['packages'].append('pyasdf.schemas')
 
 # The reference files come from a git submodule, so we deal with them here
-reference_file_root = "asdf-standard/reference_files/0.1.0"
+reference_file_root = os.path.join(
+    ASDF_STANDARD_ROOT, "reference_files", "0.1.0")
 
 package_info['package_dir']['pyasdf.reference_files'] = reference_file_root
 package_info['packages'].append('pyasdf.reference_files')


### PR DESCRIPTION
Adds support for an ASDF_STANDARD_ROOT environment variable to test again.  Makes handling git submodules much easier.
