### PR TITLE
Implement simple compression approach.

### DIFF
--- a/docs/pyasdf/examples.rst
+++ b/docs/pyasdf/examples.rst
@@ -340,3 +340,26 @@ included twice in the same tree:
         pass
 
 .. asdf:: anchors.asdf
+
+Compression
+-----------
+
+Individual blocks in an ASDF file may be zlib-compressed.
+
+You can easily `zlib <http://www.zlib.net/>`__ compress all blocks:
+
+.. runcode::
+
+   from pyasdf import AsdfFile
+   import numpy as np
+
+   tree = {
+       'a': np.random.rand(256, 256),
+       'b': np.random.rand(512, 512)
+   }
+
+   target = AsdfFile(tree)
+   with target.write_to('target.asdf', all_array_compression='zlib'):
+       pass
+
+.. asdf:: target.asdf

--- a/docs/sphinxext/example.py
+++ b/docs/sphinxext/example.py
@@ -4,9 +4,9 @@
 from __future__ import absolute_import, division, unicode_literals, print_function
 
 import atexit
+import io
 import os
 import shutil
-import sys
 import tempfile
 import textwrap
 
@@ -16,7 +16,11 @@ from docutils import nodes
 from sphinx.util.nodes import set_source_info
 
 from pyasdf import AsdfFile
-from pyasdf.constants import BLOCK_MAGIC
+from pyasdf.constants import ASDF_MAGIC, BLOCK_FLAG_STREAMED
+from pyasdf import versioning
+from pyasdf import yamlutil
+
+version_string = versioning.version_to_string(versioning.default_version)
 
 
 TMPDIR = tempfile.mkdtemp()
@@ -25,17 +29,13 @@ def delete_tmpdir():
     shutil.rmtree(TMPDIR)
 
 
-BLOCK_DISPLAY = """
-BLOCK {0}:
-    flags: 0x{1:x}
-    allocated: {2}
-    size: {3}
-    data: {4}
-"""
-
-
 GLOBALS = {}
 LOCALS = {}
+
+
+FLAGS = {
+    BLOCK_FLAG_STREAMED: "BLOCK_FLAG_STREAMED"
+}
 
 
 class RunCodeDirective(Directive):
@@ -74,11 +74,11 @@ class AsdfDirective(Directive):
         parts = []
         try:
             code = AsdfFile.read(filename, _get_yaml_content=True)
-            if len(code.strip()):
-                literal = nodes.literal_block(code, code)
-                literal['language'] = 'yaml'
-                set_source_info(self, literal)
-                parts.append(literal)
+            code = '{0}{1}\n'.format(ASDF_MAGIC, version_string) + code.strip()
+            literal = nodes.literal_block(code, code)
+            literal['language'] = 'yaml'
+            set_source_info(self, literal)
+            parts.append(literal)
 
             ff = AsdfFile.read(filename)
             for i, block in enumerate(ff.blocks.internal_blocks):
@@ -87,11 +87,30 @@ class AsdfDirective(Directive):
                     data = data[:40] + '...'
                 allocated = block._allocated
                 size = block._size
+                data_size = block._data_size
                 flags = block._flags
-                if flags:
-                    allocated = 0
-                    size = 0
-                code = BLOCK_DISPLAY.format(i, flags, allocated, size, data)
+
+                if flags & BLOCK_FLAG_STREAMED:
+                    allocated = size = data_size = 0
+
+                lines = []
+                lines.append('BLOCK {0}:'.format(i))
+
+                human_flags = []
+                for key, val in FLAGS.items():
+                    if flags & key:
+                        human_flags.append(val)
+                if len(human_flags):
+                    lines.append('    flags: {0}'.format(' | '.join(human_flags)))
+                if block.compression:
+                    lines.append('    compression: {0}'.format(block.compression))
+                lines.append('    allocated_size: {0}'.format(allocated))
+                lines.append('    used_size: {0}'.format(size))
+                lines.append('    data_size: {0}'.format(data_size))
+                lines.append('    data: {0}'.format(data))
+
+                code = '\n'.join(lines)
+
                 literal = nodes.literal_block(code, code)
                 literal['language'] = 'yaml'
                 set_source_info(self, literal)

--- a/pyasdf/block.py
+++ b/pyasdf/block.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 
 from collections import namedtuple
 import copy
+import io
 import os
 import struct
 import weakref
@@ -14,6 +15,7 @@ import numpy as np
 from astropy.extern import six
 from astropy.extern.six.moves.urllib import parse as urlparse
 
+from . import compression as mcompression
 from . import constants
 from . import generic_io
 from . import stream
@@ -118,12 +120,16 @@ class BlockManager(object):
             should be after the tree.
         """
         for block in self.internal_blocks:
-            padding = util.calculate_padding(
-                block.size, pad_blocks, fd.block_size)
-            block.allocated = block._size + padding
-            block.offset = fd.tell()
-            block.write(fd)
-            fd.fast_forward(padding)
+            if block.is_compressed:
+                block.offset = fd.tell()
+                block.write(fd)
+            else:
+                padding = util.calculate_padding(
+                    block.size, pad_blocks, fd.block_size)
+                block.allocated = block._size + padding
+                block.offset = fd.tell()
+                block.write(fd)
+                fd.fast_forward(block.allocated - block._size)
 
     def write_internal_blocks_random_access(self, fd):
         """
@@ -253,6 +259,10 @@ class BlockManager(object):
         all_array_storage = getattr(ctx, '_all_array_storage', None)
         if all_array_storage:
             block.array_storage = all_array_storage
+
+        all_array_compression = getattr(ctx, '_all_array_compression', None):
+        if all_array_compression:
+            block.compression = all_array_compression
 
         auto_inline = getattr(ctx, '_auto_inline', None)
         if auto_inline:
@@ -432,30 +442,25 @@ class Block(object):
 
     _header = util.BinaryStruct([
         ('flags', 'I'),
+        ('compression', '4s'),
         ('allocated_size', 'Q'),
         ('used_size', 'Q'),
-        ('checksum', 'Q'),
-        ('encoding', '16s'),
+        ('data_size', 'Q'),
+        ('checksum', 'Q')
     ])
 
     def __init__(self, data=None, uri=None, array_storage='internal'):
-        if data is not None:
-            self._data = data
-            if six.PY2:
-                self._size = len(data.data)
-            elif six.PY3:
-                self._size = data.data.nbytes
-        else:
-            self._data = None
-            self._size = 0
+        self._data = data
         self._uri = uri
         self._array_storage = array_storage
 
         self._fd = None
         self._offset = None
-        self._allocated = self._size
-        self._encoding = None
+        self._compression = None
         self._memmapped = False
+
+        self.update_size()
+        self._allocated = self._size
 
     def __repr__(self):
         return '<Block {0} alloc: {1} size: {2} type: {3}>'.format(
@@ -501,6 +506,39 @@ class Block(object):
                 "array_storage must be one of 'internal', 'external', "
                 "'streamed' or 'inline'")
         self._array_storage = typename
+        if typename == 'streamed':
+            self.compression = None
+
+    @property
+    def compression(self):
+        return self._compression
+
+    @compression.setter
+    def compression(self, compression):
+        self._compression = mcompression.validate(compression)
+
+    @property
+    def is_compressed(self):
+        return self._compression is not None
+
+    def update_size(self):
+        """
+        Recalculate the on-disk size of the block.  This causes any
+        compression steps to run.  It should only be called when
+        updating the file in-place, otherwise the work is redundant.
+        """
+        if self._data is not None:
+            if six.PY2:
+                self._data_size = len(self._data.data)
+            else:
+                self._data_size = self._data.data.nbytes
+            if not self.is_compressed:
+                self._size = self._data_size
+            else:
+                self._size = mcompression.get_compressed_size(
+                    self._data, self.compression)
+        else:
+            self._data_size = self._size = 0
 
     def read(self, fd, past_magic=False):
         """
@@ -551,6 +589,17 @@ class Block(object):
 
         # This is used by the documentation system, but nowhere else.
         self._flags = header['flags']
+        self.compression = header['compression']
+
+        if (self.compression is None and
+            header['used_size'] != header['data_size']):
+            raise ValueError(
+                "used_size and data_size must be equal when no compression is used.")
+
+        if (header['flags'] & constants.BLOCK_FLAG_STREAMED and
+            self.compression is not None):
+            raise ValueError(
+                "Compression set on a streamed block.")
 
         if fd.seekable():
             # If the file is seekable, we can delay reading the actual
@@ -562,26 +611,37 @@ class Block(object):
                 # Support streaming blocks
                 fd.fast_forward(-1)
                 self._array_storage = 'streamed'
-                self._size = self._allocated = (fd.tell() - self.data_offset) + 1
+                self._data_size = self._size = self._allocated = \
+                                  (fd.tell() - self.data_offset) + 1
             else:
                 fd.fast_forward(header['allocated_size'])
                 self._allocated = header['allocated_size']
                 self._size = header['used_size']
+                self._data_size = header['data_size']
         else:
             # If the file is a stream, we need to get the data now.
             if header['flags'] & constants.BLOCK_FLAG_STREAMED:
                 # Support streaming blocks
                 self._array_storage = 'streamed'
                 self._data = fd.read_into_array(-1)
-                self._size = self._allocated = len(self._data)
+                self._data_size = self._size = self._allocated = len(self._data)
             else:
+                self._data_size = header['data_size']
                 self._size = header['used_size']
                 self._allocated = header['allocated_size']
-                self._data = fd.read_into_array(self._size)
+                self._data = self._read_data(
+                    fd, self._size, self._data_size, self.compression)
                 fd.fast_forward(self._allocated - self._size)
             fd.close()
 
         return self
+
+    def _read_data(self, fd, used_size, data_size, compression):
+        if not compression:
+            return fd.read_into_array(used_size)
+        else:
+            return mcompression.decompress(
+                fd, used_size, data_size, compression)
 
     def write(self, fd):
         """
@@ -591,17 +651,49 @@ class Block(object):
             self._header_size = self._header.size
 
             flags = 0
+            data_size = used_size = allocated_size = 0
             if self._array_storage == 'streamed':
                 flags |= constants.BLOCK_FLAG_STREAMED
+            elif self._data is not None:
+                if not fd.seekable() and self.is_compressed:
+                    buff = io.BytesIO()
+                    mcompression.compress(buff, self._data, self.compression)
+                    self.allocated = self._size = buff.tell()
+                data_size = self._data.nbytes
+                allocated_size = self.allocated
+                used_size = self._size
 
             fd.write(constants.BLOCK_MAGIC)
             fd.write(struct.pack(b'>H', self._header_size))
             fd.write(self._header.pack(
-                flags=flags, allocated_size=self.allocated,
-                used_size=self._size, checksum=0, encoding=b''))
+                flags=flags,
+                compression=mcompression.to_compression_header(
+                    self.compression),
+                allocated_size=allocated_size,
+                used_size=used_size, data_size=data_size,
+                checksum=0))
 
             if self._data is not None:
-                fd.write_array(self._data)
+                if self.is_compressed:
+                    if not fd.seekable():
+                        fd.write(buff.getvalue())
+                    else:
+                        # If the file is seekable, we write the
+                        # compressed data directly to it, then go back
+                        # and write the resulting size in the block
+                        # header.
+                        start = fd.tell()
+                        mcompression.compress(fd, self._data, self.compression)
+                        end = fd.tell()
+                        self.allocated = self._size = end - start
+                        fd.seek(self.offset + 6)
+                        self._header.update(
+                            fd,
+                            allocated_size=self.allocated,
+                            used_size=self._size)
+                        fd.seek(end)
+                else:
+                    fd.write_array(self._data)
 
     @property
     def data(self):
@@ -614,7 +706,7 @@ class Block(object):
                     "ASDF file has already been closed. "
                     "Can not get the data.")
 
-            if self._fd.can_memmap():
+            if not self.is_compressed and self._fd.can_memmap():
                 self._data = self._fd.memmap_array(
                     self.data_offset, self._size)
                 self._memmapped = True
@@ -624,7 +716,8 @@ class Block(object):
                 curpos = self._fd.tell()
                 try:
                     self._fd.seek(self.data_offset)
-                    self._data = self._fd.read_into_array(self._size)
+                    self._data = self._read_data(
+                        self._fd, self._size, self._data_size, self.compression)
                 finally:
                     self._fd.seek(curpos)
 
@@ -669,6 +762,7 @@ def calculate_updated_layout(blocks, tree_size, pad_blocks, block_size):
     for block in blocks._blocks:
         if block.array_storage == 'internal':
             if block.offset is not None:
+                block.update_size()
                 fixed.append(
                     Entry(block.offset, block.offset + block.size, block))
             else:

--- a/pyasdf/block.py
+++ b/pyasdf/block.py
@@ -260,7 +260,7 @@ class BlockManager(object):
         if all_array_storage:
             block.array_storage = all_array_storage
 
-        all_array_compression = getattr(ctx, '_all_array_compression', None):
+        all_array_compression = getattr(ctx, '_all_array_compression', None)
         if all_array_compression:
             block.compression = all_array_compression
 

--- a/pyasdf/compression.py
+++ b/pyasdf/compression.py
@@ -1,0 +1,162 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, unicode_literals, print_function
+
+import zlib
+
+import numpy as np
+
+from astropy.extern import six
+from astropy.extern.six.moves import xrange
+
+
+def validate(compression):
+    """
+    Validate the compression string.
+
+    Parameters
+    ----------
+    compression : str or None
+
+    Returns
+    -------
+    compression : str or None
+        In canonical form.
+
+    Raises
+    ------
+    ValueError
+    """
+    if not compression:
+        return None
+
+    if compression == b'\0\0\0\0':
+        return None
+
+    if isinstance(compression, bytes):
+        compression = compression.decode('ascii')
+
+    if compression != 'zlib':
+        raise ValueError("Supported compression types are: 'zlib'")
+
+    return compression
+
+
+def to_compression_header(compression):
+    """
+    Converts a compression string to the four byte field in a block
+    header.
+    """
+    if not compression:
+        return b''
+
+    if isinstance(compression, six.text_type):
+        return compression.encode('ascii')
+
+    return compression
+
+
+def decompress(fd, used_size, data_size, compression):
+    """
+    Decompress binary data in a file
+
+    Parameters
+    ----------
+    fd : generic_io.GenericIO object
+         The file to read the compressed data from.
+
+    used_size : int
+         The size of the compressed data
+
+    data_size : int
+         The size of the uncompressed data
+
+    compression : str
+         The compression type used.  Currently, only ``zlib`` is
+         supported.
+
+    Returns
+    -------
+    array : numpy.array
+         A flat uint8 containing the decompressed data.
+    """
+    buffer = np.empty((data_size,), np.uint8)
+
+    compression = validate(compression)
+
+    decoder = zlib.decompressobj()
+
+    i = 0
+    for block in fd.read_blocks(used_size):
+        decoded = decoder.decompress(block)
+        if i + len(decoded) > data_size:
+            raise ValueError("Decompressed data too long")
+        buffer.data[i:i+len(decoded)] = decoded
+        i += len(decoded)
+
+    decoded = decoder.flush()
+    if i + len(decoded) > data_size:
+        raise ValueError("Decompressed data too long")
+    elif i + len(decoded) < data_size:
+        raise ValueError("Decompressed data too short")
+    buffer[i:i+len(decoded)] = decoded
+
+    return buffer
+
+
+def compress(fd, data, compression, block_size=1 << 16):
+    """
+    Compress array data and write to a file.
+
+    Parameters
+    ----------
+    fd : generic_io.GenericIO object
+        The file to write to.
+
+    data : buffer
+        The buffer of uncompressed data
+
+    compression : str
+        The type of compression to use.  Currently, only ``zlib`` is
+        supported.
+
+    block_size : int, optional
+        The size of blocks (in raw data) to process at a time.
+    """
+    compression = validate(compression)
+
+    encoder = zlib.compressobj()
+
+    for i in range(0, len(data), block_size):
+        fd.write(encoder.compress(data[i:i+block_size]))
+    fd.write(encoder.flush())
+
+
+def get_compressed_size(data, compression, block_size=1 << 16):
+    """
+    Returns the number of bytes required when the given data is
+    compressed.
+
+    Parameters
+    ----------
+    data : buffer
+
+    compression : str
+        The type of compression to use.  Currently, only ``zlib`` is
+        supported.
+
+    Returns
+    -------
+    bytes : int
+    """
+    compression = validate(compression)
+
+    encoder = zlib.compressobj()
+
+    l = 0
+    for i in range(0, len(data), block_size):
+        l += len(encoder.compress(data[i:i+block_size]))
+    l += len(encoder.flush())
+
+    return l

--- a/pyasdf/generic_io.py
+++ b/pyasdf/generic_io.py
@@ -262,6 +262,18 @@ class GenericFile(object):
         """
         return self.read(self._blksize)
 
+    def read_blocks(self, size):
+        """
+        Read ``size`` bytes of data from the file, one block at a
+        time.  The result is a generator where each value is a bytes
+        object.
+        """
+        i = 0
+        for i in xrange(0, size - self._blksize, self._blksize):
+            yield self.read(self._blksize)
+        if i < size:
+            yield self.read(size - i)
+
     if sys.version_info[:2] == (2, 7) and sys.version_info[2] < 4:
         # On Python 2.7.x prior to 2.7.4, the buffer does not support the
         # new buffer interface, and thus can't be written directly.  See

--- a/pyasdf/tests/test_compression.py
+++ b/pyasdf/tests/test_compression.py
@@ -1,0 +1,85 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, unicode_literals, print_function
+
+import io
+import os
+
+import numpy as np
+
+from astropy.tests.helper import pytest
+
+from .. import asdf
+from .. import generic_io
+from ..tests import helpers
+
+
+def _get_large_tree():
+    np.random.seed(0)
+    x = np.random.rand(128, 128)
+    tree = {
+        'science_data': x,
+        }
+    return tree
+
+
+def _get_sparse_tree():
+    np.random.seed(0)
+    arr = np.zeros((128, 128))
+    for x, y, z in np.random.rand(64, 3):
+        arr[int(x*127), int(y*127)] = z
+    arr[0, 0] = 5.0
+    tree = {'science_data': arr}
+    return tree
+
+
+def _roundtrip(tmpdir, tree, compression=None,
+               write_options={}, read_options={}):
+    tmpfile = os.path.join(str(tmpdir), 'test.asdf')
+
+    with asdf.AsdfFile(tree) as ff:
+        ff.set_array_compression(tree['science_data'], compression)
+        ff.write_to(tmpfile, **write_options)
+        ff.update(**write_options)
+
+    with asdf.AsdfFile().read(tmpfile, **read_options) as ff:
+        helpers.assert_tree_match(tree, ff.tree)
+
+    # Also test saving to a buffer
+    buff = io.BytesIO()
+
+    with asdf.AsdfFile(tree) as ff:
+        ff.set_array_compression(tree['science_data'], compression)
+        ff.write_to(buff, **write_options)
+
+    buff.seek(0)
+    with asdf.AsdfFile().read(buff, **read_options) as ff:
+        helpers.assert_tree_match(tree, ff.tree)
+
+    # Test saving to a non-seekable buffer
+
+    buff = io.BytesIO()
+
+    with asdf.AsdfFile(tree) as ff:
+        ff.set_array_compression(tree['science_data'], compression)
+        ff.write_to(generic_io.OutputStream(buff), **write_options)
+
+    buff.seek(0)
+    with asdf.AsdfFile().read(generic_io.InputStream(buff), **read_options) as ff:
+        helpers.assert_tree_match(tree, ff.tree)
+
+    return ff
+
+
+def test_invalid_compression():
+    tree = _get_large_tree()
+    ff = asdf.AsdfFile(tree)
+    with pytest.raises(ValueError):
+        ff.set_array_compression(tree['science_data'], 'foo')
+
+
+def test_zlib(tmpdir):
+    tree = _get_large_tree()
+
+    _roundtrip(tmpdir, tree, 'zlib')


### PR DESCRIPTION
This is a replacement for the much more complex approach in #51.  This just does simple compression of the block using only `zlib` compression.

The plan is to use transforms to do more complex lossy compression at a later date and just get the simplest possible thing that can work in now.