### PR TITLE
Add checksum support

### DIFF
--- a/pyasdf/asdf.py
+++ b/pyasdf/asdf.py
@@ -326,6 +326,7 @@ class AsdfFile(versioning.VersionedMixin):
 
     @classmethod
     def read(cls, fd, uri=None, mode='r',
+             validate_checksums=False,
              tag_to_schema_resolver=None,
              url_mapping=None,
              type_index=None,
@@ -346,6 +347,10 @@ class AsdfFile(versioning.VersionedMixin):
         mode : string, optional
             The mode to open the file in.  Must be ``r`` (default) or
             ``rw``.
+
+        validate_checksums : bool, optional
+            If `True`, validate the blocks against their checksums.
+            Requires reading the entire file, so disabled by default.
 
         Other Parameters
         ----------------
@@ -394,7 +399,8 @@ class AsdfFile(versioning.VersionedMixin):
             return yaml_content
 
         if has_blocks:
-            self._blocks.read_internal_blocks(fd, past_magic=True)
+            self._blocks.read_internal_blocks(
+                fd, past_magic=True, validate_checksums=validate_checksums)
 
         if len(yaml_content):
             tree = yamlutil.load_tree(yaml_content, self)

--- a/pyasdf/block.py
+++ b/pyasdf/block.py
@@ -556,8 +556,6 @@ class Block(object):
         """
         if self._checksum:
             checksum = self._calculate_checksum(self.data)
-            print(repr(checksum))
-            print(repr(self._checksum))
             if checksum != self._checksum:
                 return False
         return True

--- a/pyasdf/tests/test_low_level.py
+++ b/pyasdf/tests/test_low_level.py
@@ -657,7 +657,8 @@ def test_get_data_from_closed_file(tmpdir):
     tmpdir = str(tmpdir)
     path = os.path.join(tmpdir, 'test.asdf')
 
-    my_array = np.random.rand(8, 8)
+    my_array = np.arange(0, 64).reshape((8, 8))
+
     tree = {'my_array': my_array}
     with asdf.AsdfFile(tree) as ff:
         ff.write_to(path)
@@ -705,22 +706,23 @@ def test_checksum(tmpdir):
     with asdf.AsdfFile.read(path, validate_checksums=True) as ff:
         assert type(ff.blocks._blocks[0].checksum) == bytes
         assert ff.blocks._blocks[0].checksum == \
-            b'\xc7\xa1\xa0\\\x0e=\xbb\x93\x11\x94\x8amU+\xe1i'
+            b'\xcaM\\\xb8t_L|\x00\n+\x01\xf1\xcfP1'
 
 
 def test_checksum_update(tmpdir):
     tmpdir = str(tmpdir)
     path = os.path.join(tmpdir, 'test.asdf')
 
-    my_array = np.random.rand(8, 8)
+    my_array = np.arange(0, 64).reshape((8, 8))
+
     tree = {'my_array': my_array}
     with asdf.AsdfFile(tree) as ff:
         ff.write_to(path)
-        my_array[0, 0] = 0.0
+        my_array[7, 7] = 0.0
         # update() should update the checksum, even if the data itself
         # is memmapped and isn't expressly re-written.
         ff.update()
 
     with asdf.AsdfFile.read(path, validate_checksums=True) as ff:
         assert ff.blocks._blocks[0].checksum == \
-            b'-d1\xcf\n.M\xbb\xf3\xe7\x91\xe8\x88e\t\xe6'
+            b'T\xaf~[\x90\x8a\x88^\xc2B\x96D,N\xadL'

--- a/pyasdf/tests/test_suite.py
+++ b/pyasdf/tests/test_suite.py
@@ -28,7 +28,7 @@ def test_reference_files():
                 asdf.resolve_and_inline()
 
                 with open(filename[:-4] + "yaml") as ref:
-                        assert_tree_match(asdf.tree, ref.tree, 'assert_allclose')
+                    assert_tree_match(asdf.tree, ref.tree, 'assert_allclose')
         except:
             if known_fail:
                 pytest.xfail()


### PR DESCRIPTION
@embray I'd appreciate your comments on this.

Right now it's using MD5 hashes.  Should we consider a different/longer hash?  Any strong argument in favor of storing the hash type in the file (and thus opening this up to multiple hash algorithms in the future)?

This implementation only validates the checksums when an explicit flag is passed to `read`, to avoid unnecessarily reading the entire file.  It always writes checksums to the file, unless the data was memmapped and never accessed at all, since in that case we can assume the existing checksum is still valid.  This does mean that updating the file in place will result in streaming in the entire contents of any data that was accessed (it would be nice to do that only if *writes* were made, but I don't think there's a way to get that info from memmap).  I *think* that might be a good tradeoff to encourage people to store checksums in the file, while avoiding the read-time downsides.  But I could imagine also either (a) adding an option to not update the checksums on writing (and thus store zeros in the checksum field to indicate "no checksum") or (b) make not writing checksums the default (which I fear would limit their use in the wild).  Any thoughts or experience from pyfits?