### PR TITLE
Use C yaml parser

### DIFF
--- a/pyasdf/tests/test_low_level.py
+++ b/pyasdf/tests/test_low_level.py
@@ -30,7 +30,7 @@ def _get_small_tree():
 
 def test_no_yaml_end_marker(tmpdir):
     content = b"""#ASDF 0.1.0
-%YAML 1.2
+%YAML 1.1
 %TAG ! tag:stsci.edu:asdf/0.1.0/
 --- !core/asdf
 foo: bar...baz
@@ -57,7 +57,7 @@ baz: 42
 
 def test_no_final_newline(tmpdir):
     content = b"""#ASDF 0.1.0
-%YAML 1.2
+%YAML 1.1
 %TAG ! tag:stsci.edu:asdf/0.1.0/
 --- !core/asdf
 foo: ...bar...
@@ -101,7 +101,7 @@ def test_no_asdf_header(tmpdir):
 
 def test_no_asdf_blocks(tmpdir):
     content = b"""#ASDF 0.1.0
-%YAML 1.2
+%YAML 1.1
 %TAG ! tag:stsci.edu:asdf/0.1.0/
 --- !core/asdf
 foo: bar
@@ -675,7 +675,7 @@ def test_seek_until_on_block_boundary():
     # file-reading-block boundary.
 
     content = b"""#ASDF 0.1.0
-%YAML 1.2
+%YAML 1.1
 %TAG ! tag:stsci.edu:asdf/0.1.0/
 --- !core/asdf
 foo : bar

--- a/pyasdf/yamlutil.py
+++ b/pyasdf/yamlutil.py
@@ -18,6 +18,14 @@ from . import treeutil
 from . import util
 
 
+if getattr(yaml, '__with_libyaml__', None):
+    _yaml_base_dumper = yaml.CSafeDumper
+    _yaml_base_loader = yaml.CSafeLoader
+else:
+    _yaml_base_dumper = yaml.SafeDumper
+    _yaml_base_loader = yaml.SafeLoader
+
+
 # ----------------------------------------------------------------------
 # Custom loader/dumpers
 
@@ -51,7 +59,7 @@ def yaml_to_base_type(node, loader):
             type(node)))
 
 
-class AsdfDumper(yaml.CSafeDumper):
+class AsdfDumper(_yaml_base_dumper):
     """
     A specialized YAML dumper that understands "tagged basic Python
     data types" as implemented in the `tagged` module.
@@ -122,7 +130,7 @@ AsdfDumper.add_representer(tagged.TaggedDict, represent_mapping)
 AsdfDumper.add_representer(tagged.TaggedString, represent_scalar)
 
 
-class AsdfLoader(yaml.CSafeLoader):
+class AsdfLoader(_yaml_base_loader):
     """
     A specialized YAML loader that can construct "tagged basic Python
     data types" as implemented in the `tagged` module.

--- a/pyasdf/yamlutil.py
+++ b/pyasdf/yamlutil.py
@@ -51,7 +51,7 @@ def yaml_to_base_type(node, loader):
             type(node)))
 
 
-class AsdfDumper(yaml.SafeDumper):
+class AsdfDumper(yaml.CSafeDumper):
     """
     A specialized YAML dumper that understands "tagged basic Python
     data types" as implemented in the `tagged` module.
@@ -122,7 +122,7 @@ AsdfDumper.add_representer(tagged.TaggedDict, represent_mapping)
 AsdfDumper.add_representer(tagged.TaggedString, represent_scalar)
 
 
-class AsdfLoader(yaml.SafeLoader):
+class AsdfLoader(yaml.CSafeLoader):
     """
     A specialized YAML loader that can construct "tagged basic Python
     data types" as implemented in the `tagged` module.


### PR DESCRIPTION
I wasn't aware that pyyaml doesn't use the C libyaml-based parser/dumper by default.