### PR TITLE
Improve performance of schema validation

### DIFF
--- a/pyasdf/__init__.py
+++ b/pyasdf/__init__.py
@@ -27,5 +27,7 @@ from . import commands
 
 from jsonschema import ValidationError
 
+class ValidationError(ValidationError):
+    pass
 
 open = AsdfFile.read

--- a/pyasdf/__init__.py
+++ b/pyasdf/__init__.py
@@ -15,13 +15,17 @@ from ._astropy_init import *
 # ----------------------------------------------------------------------------
 
 __all__ = ['AsdfFile', 'AsdfType', 'AsdfExtension',
-           'Stream', 'open', 'test', 'commands']
+           'Stream', 'open', 'test', 'commands',
+           'ValidationError']
+
 
 from .asdf import AsdfFile
 from .asdftypes import AsdfType
 from .extension import AsdfExtension
 from .stream import Stream
 from . import commands
+
+from jsonschema import ValidationError
 
 
 open = AsdfFile.read

--- a/pyasdf/asdf.py
+++ b/pyasdf/asdf.py
@@ -13,8 +13,9 @@ from . import constants
 from . import extension
 from . import generic_io
 from . import reference
-from . import util
+from . import schema
 from . import treeutil
+from . import util
 from . import versioning
 from . import yamlutil
 
@@ -177,8 +178,9 @@ class AsdfFile(versioning.VersionedMixin):
 
     @tree.setter
     def tree(self, tree):
-        yamlutil.validate(tree, self)
-
+        tagged_tree = yamlutil.custom_tree_to_tagged_tree(
+            AsdfObject(tree), self)
+        schema.validate(tagged_tree, self)
         self._tree = AsdfObject(tree)
 
     def make_reference(self, path=[]):

--- a/pyasdf/asdftypes.py
+++ b/pyasdf/asdftypes.py
@@ -144,15 +144,6 @@ class AsdfType(object):
             name)
 
     @classmethod
-    def validate(cls, tree, ctx):
-        """
-        Validate the given tree of basic data types against the schema
-        for this type.
-        """
-        from . import yamlutil
-        yamlutil.validate_for_tag(cls.yaml_tag, tree, ctx)
-
-    @classmethod
     def to_tree(cls, node, ctx):
         """
         Converts from a custom type to any of the basic types (dict,

--- a/pyasdf/schema.py
+++ b/pyasdf/schema.py
@@ -210,17 +210,20 @@ def _create_validator():
 
 
 @lru_cache()
+def _load_schema(url):
+    with generic_io.get_file(url) as fd:
+        if isinstance(url, six.text_type) and url.endswith('json'):
+            result = json.load(fd)
+        else:
+            result = yaml.load(fd, Loader=_yaml_base_loader)
+    return result
+
+
+@lru_cache()
 def _make_schema_loader(resolver):
-    @lru_cache()
     def load_schema(url):
         url = resolver(url)
-        with generic_io.get_file(url) as fd:
-            if isinstance(url, six.text_type) and url.endswith('json'):
-                result = json.load(fd)
-            else:
-                result = yaml.load(fd, Loader=_yaml_base_loader)
-        return result
-
+        return _load_schema(url)
     return load_schema
 
 

--- a/pyasdf/schema.py
+++ b/pyasdf/schema.py
@@ -219,7 +219,6 @@ def _load_schema(url):
     return result
 
 
-@lru_cache()
 def _make_schema_loader(resolver):
     def load_schema(url):
         url = resolver(url)

--- a/pyasdf/tagged.py
+++ b/pyasdf/tagged.py
@@ -38,7 +38,7 @@ from astropy.extern import six
 from .compat import UserDict, UserList, UserString
 
 
-__all__ = ['tag_object', 'get_tag', 'walk_and_modify_with_tags']
+__all__ = ['tag_object', 'get_tag']
 
 
 class Tagged(object):

--- a/pyasdf/tests/data/custom.yaml
+++ b/pyasdf/tests/data/custom.yaml
@@ -1,0 +1,5 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://nowhere.org/schemas/custom/1.0.0/custom"
+type: integer

--- a/pyasdf/treeutil.py
+++ b/pyasdf/treeutil.py
@@ -32,7 +32,7 @@ def walk(top, callback):
     tree : object
         The modified tree.
     """
-    def recurse(tree, seen=set()):
+    def recurse(tree, seen):
         if id(tree) in seen:
             return
 
@@ -47,7 +47,7 @@ def walk(top, callback):
 
         callback(tree)
 
-    return recurse(top)
+    return recurse(top, set())
 
 
 def walk_and_modify(top, callback):
@@ -73,7 +73,7 @@ def walk_and_modify(top, callback):
     tree : object
         The modified tree.
     """
-    def recurse(tree, seen=set()):
+    def recurse(tree, seen):
         if id(tree) in seen:
             return tree
 
@@ -96,4 +96,4 @@ def walk_and_modify(top, callback):
 
         return result
 
-    return recurse(top)
+    return recurse(top, set())


### PR DESCRIPTION
This will now validate and recurse the tree only once per YAML tag.  It still may recurse multiple times over the same parts of the tree, but I don't see a way around that given how JSON schema works.

This is about a 15% improvement in JSON schema validation.