### PR TITLE
ASDF-in-FITS embedding

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -79,3 +79,5 @@ Reference/API
 -------------
 
 .. automodapi:: pyasdf
+
+.. automodapi:: pyasdf.fits_embed

--- a/docs/pyasdf/examples.rst
+++ b/docs/pyasdf/examples.rst
@@ -279,7 +279,7 @@ to the target file.
    with AsdfFile.open('target.asdf') as target:
        ff.tree['my_ref_a'] = target.make_reference(['a'])
 
-   ff.tree['my_ref_b'] = {'$ref': 'target.asdf#/b'}
+   ff.tree['my_ref_b'] = {'$ref': 'target.asdf#b'}
 
    ff.write_to('source.asdf')
 

--- a/docs/pyasdf/examples.rst
+++ b/docs/pyasdf/examples.rst
@@ -356,3 +356,68 @@ You can easily `zlib <http://www.zlib.net/>`__ or `bzip2
    target.write_to('target.asdf', all_array_compression='bzp2')
 
 .. asdf:: target.asdf
+
+Saving ASDF in FITS
+-------------------
+
+Sometimes you may need to store the structured data supported by ASDF
+inside of a FITS file in order to be compatible with legacy tools that
+support only FITS.  This can be achieved by including a special
+extension with the name ``ASDF`` to the FITS file, containing the YAML
+tree from an ASDF file.  The array tags within the ASDF tree point
+directly to other binary extensions in the FITS file.
+
+First, make a FITS file in the usual way with astropy.io.fits.  Here,
+we are building a FITS file from scratch, but it could also have been
+loaded from a file.
+
+This FITS file has two image extensions, SCI and DQ respectively.
+
+.. runcode::
+
+    from astropy.io import fits
+
+    hdulist = fits.HDUList()
+    hdulist.append(fits.ImageHDU(np.arange(512, dtype=np.float), name='SCI'))
+    hdulist.append(fits.ImageHDU(np.arange(512, dtype=np.float), name='DQ'))
+
+Next we make a tree structure out of the data in the FITS file.
+Importantly, we use the *same* arrays in the FITS HDUList and store
+them in the tree.  By doing this, pyasdf will be smart enough to point
+to the data in the regular FITS extensions.
+
+.. runcode::
+
+    tree = {
+        'model': {
+            'sci': {
+                'data': hdulist['SCI'].data,
+            },
+            'dq': {
+                'data': hdulist['DQ'].data,
+            }
+        }
+    }
+
+Now we take both the FITS HDUList and the ASDF tree and create a
+`~pyasdf.fits_embed.AsdfInFits` object.  It behaves identically to the
+`~pyasdf.AsdfFile` object, but reads and writes this special
+ASDF-in-FITS format.
+
+.. runcode::
+
+    from pyasdf import fits_embed
+
+    ff = fits_embed.AsdfInFits(hdulist, tree)
+    ff.write_to('embedded_asdf.fits')
+
+.. runcode:: hidden
+
+    with open('content.asdf', 'wb') as fd:
+        fd.write(hdulist['ASDF'].data.tostring())
+
+The special ASDF extension in the resulting FITS file looks like the
+following.  Note that the data source of the arrays uses the ``fits:``
+prefix to indicate that the data comes from a FITS extension.
+
+.. asdf:: content.asdf

--- a/docs/pyasdf/examples.rst
+++ b/docs/pyasdf/examples.rst
@@ -421,3 +421,13 @@ following.  Note that the data source of the arrays uses the ``fits:``
 prefix to indicate that the data comes from a FITS extension.
 
 .. asdf:: content.asdf
+
+To load an ASDF-in-FITS file, first open it with ``astropy.io.fits``, and then
+pass that HDU list to `~pyasdf.fits_embed.AsdfInFits`:
+
+
+.. runcode::
+
+    with fits.open('embedded_asdf.fits') as hdulist:
+        with fits_embed.AsdfInFits.open(hdulist) as asdf:
+            science = asdf.tree['model']['sci']

--- a/docs/sphinxext/example.py
+++ b/docs/sphinxext/example.py
@@ -79,7 +79,8 @@ class AsdfDirective(Directive):
 
         parts = []
         try:
-            code = AsdfFile.open(filename, _get_yaml_content=True)
+            ff = AsdfFile()
+            code = AsdfFile._open_impl(ff, filename, _get_yaml_content=True)
             code = '{0}{1}\n'.format(ASDF_MAGIC, version_string) + code.strip().decode('utf-8')
             literal = nodes.literal_block(code, code)
             literal['language'] = 'yaml'

--- a/docs/sphinxext/example.py
+++ b/docs/sphinxext/example.py
@@ -41,6 +41,7 @@ FLAGS = {
 
 class RunCodeDirective(Directive):
     has_content = True
+    optional_arguments = 1
 
     def run(self):
         code = textwrap.dedent('\n'.join(self.content))
@@ -60,7 +61,11 @@ class RunCodeDirective(Directive):
             set_source_info(self, literal)
         finally:
             os.chdir(cwd)
-        return [literal]
+
+        if 'hidden' not in self.arguments:
+            return [literal]
+        else:
+            return []
 
 
 class AsdfDirective(Directive):

--- a/pyasdf/asdf.py
+++ b/pyasdf/asdf.py
@@ -316,53 +316,12 @@ class AsdfFile(versioning.VersionedMixin):
                 int(match.group("micro")))
 
     @classmethod
-    def open(cls, fd, uri=None, mode='r',
-             validate_checksums=False,
-             extensions=None,
-             do_not_fill_defaults=False,
-             _get_yaml_content=False):
-        """
-        Open an existing ASDF file.
-
-        By default, any missing values which have a default value
-        specified in the schema will be added to the tree after
-        loading.  To disable this, set ``do_not_fill_defaults`` to
-        `True`.
-
-        Parameters
-        ----------
-        fd : string or file-like object
-            May be a string ``file`` or ``http`` URI, or a Python
-            file-like object.
-
-        uri : string, optional
-            The URI of the file.  Only required if the URI can not be
-            automatically determined from `fd`.
-
-        mode : string, optional
-            The mode to open the file in.  Must be ``r`` (default) or
-            ``rw``.
-
-        validate_checksums : bool, optional
-            If `True`, validate the blocks against their checksums.
-            Requires reading the entire file, so disabled by default.
-
-        extensions : list of AsdfExtension, optional
-            A list of extensions to the ASDF to support when reading
-            and writing ASDF files.  See `asdftypes.AsdfExtension` for
-            more information.
-
-        do_not_fill_defaults : bool, optional
-            When `True`, don't fill in default values in the tree.
-
-        Returns
-        -------
-        asdffile : AsdfFile
-            The new AsdfFile object.
-        """
+    def _open_impl(cls, self, fd, uri=None, mode='r',
+                   validate_checksums=False,
+                   do_not_fill_defaults=False,
+                   _get_yaml_content=False):
         fd = generic_io.get_file(fd, mode=mode, uri=uri)
 
-        self = cls(extensions=extensions)
         self._fd = fd
 
         try:
@@ -405,6 +364,53 @@ class AsdfFile(versioning.VersionedMixin):
             self._tree = {}
 
         return self
+
+    @classmethod
+    def open(cls, fd, uri=None, mode='r',
+             validate_checksums=False,
+             extensions=None,
+             do_not_fill_defaults=False,
+             _get_yaml_content=False):
+        """
+        Open an existing ASDF file.
+
+        Parameters
+        ----------
+        fd : string or file-like object
+            May be a string ``file`` or ``http`` URI, or a Python
+            file-like object.
+
+        uri : string, optional
+            The URI of the file.  Only required if the URI can not be
+            automatically determined from `fd`.
+
+        mode : string, optional
+            The mode to open the file in.  Must be ``r`` (default) or
+            ``rw``.
+
+        validate_checksums : bool, optional
+            If `True`, validate the blocks against their checksums.
+            Requires reading the entire file, so disabled by default.
+
+        extensions : list of AsdfExtension
+            A list of extensions to the ASDF to support when reading
+            and writing ASDF files.  See `asdftypes.AsdfExtension` for
+            more information.
+
+        do_not_fill_defaults : bool, optional
+            When `True`, do not fill in missing default values.
+
+        Returns
+        -------
+        asdffile : AsdfFile
+            The new AsdfFile object.
+        """
+        self = cls(extensions=extensions)
+
+        return cls._open_impl(
+            self, fd, uri=uri, mode=mode,
+            validate_checksums=validate_checksums,
+            _get_yaml_content=_get_yaml_content)
 
     def _write_tree(self, tree, fd, pad_blocks):
         fd.write(constants.ASDF_MAGIC)

--- a/pyasdf/asdf.py
+++ b/pyasdf/asdf.py
@@ -410,6 +410,7 @@ class AsdfFile(versioning.VersionedMixin):
         return cls._open_impl(
             self, fd, uri=uri, mode=mode,
             validate_checksums=validate_checksums,
+            do_not_fill_defaults=do_not_fill_defaults,
             _get_yaml_content=_get_yaml_content)
 
     def _write_tree(self, tree, fd, pad_blocks):

--- a/pyasdf/asdf.py
+++ b/pyasdf/asdf.py
@@ -369,8 +369,7 @@ class AsdfFile(versioning.VersionedMixin):
     def open(cls, fd, uri=None, mode='r',
              validate_checksums=False,
              extensions=None,
-             do_not_fill_defaults=False,
-             _get_yaml_content=False):
+             do_not_fill_defaults=False):
         """
         Open an existing ASDF file.
 
@@ -410,8 +409,7 @@ class AsdfFile(versioning.VersionedMixin):
         return cls._open_impl(
             self, fd, uri=uri, mode=mode,
             validate_checksums=validate_checksums,
-            do_not_fill_defaults=do_not_fill_defaults,
-            _get_yaml_content=_get_yaml_content)
+            do_not_fill_defaults=do_not_fill_defaults)
 
     def _write_tree(self, tree, fd, pad_blocks):
         fd.write(constants.ASDF_MAGIC)

--- a/pyasdf/fits_embed.py
+++ b/pyasdf/fits_embed.py
@@ -1,0 +1,145 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, unicode_literals, print_function
+
+"""
+Utilities for embedded ADSF files in FITS.
+"""
+import io
+import re
+
+import numpy as np
+
+from astropy.extern import six
+from astropy.io import fits
+
+from . import asdf
+from . import block
+from . import util
+
+
+ASDF_EXTENSION_NAME = 'ASDF'
+
+
+class _FitsBlock(object):
+    def __init__(self, hdu):
+        self._hdu = hdu
+
+    def __repr__(self):
+        return '<FitsBlock {0},{1}>'.format(self._hdu.name, self._hdu.ver)
+
+    def __len__(self):
+        return self._hdu.data.nbytes
+
+    @property
+    def data(self):
+        return self._hdu.data
+
+    @property
+    def array_storage(self):
+        return 'fits'
+
+
+class _EmbeddedBlockManager(block.BlockManager):
+    def __init__(self, hdulist, asdffile):
+        self._hdulist = hdulist
+
+        super(_EmbeddedBlockManager, self).__init__(asdffile)
+
+    def get_block(self, source):
+        if isinstance(source, six.string_types) and source.startswith('fits:'):
+            parts = re.match(
+                '(?P<name>[A-Z0-9]+)(,(?P<ver>[0-9]+))?', source[5:])
+            if parts is not None:
+                name = parts.group('name')
+                if parts.group('ver'):
+                    ver = int(parts.group('ver'))
+                    pair = name, ver
+                else:
+                    pair = name
+                return _FitsBlock(self._hdulist[pair])
+
+        return super(_EmbeddedBlockManager, self).get_block(source)
+
+    def get_source(self, block):
+        if isinstance(block, _FitsBlock):
+            for hdu in self._hdulist:
+                if hdu is block._hdu:
+                    return 'fits:{0},{1}'.format(hdu.name, hdu.ver)
+            raise ValueError("FITS block seems to have been removed")
+
+        return super(_EmbeddedBlockManager, self).get_source(block)
+
+    def find_or_create_block_for_array(self, arr, ctx):
+        from .tags.core import ndarray
+
+        if not isinstance(arr, ndarray.NDArrayType):
+            base = util.get_array_base(arr)
+            for hdu in self._hdulist:
+                if base is hdu.data:
+                    return _FitsBlock(hdu)
+
+        return super(_EmbeddedBlockManager, self).find_or_create_block_for_array(
+            arr, ctx)
+
+
+class AsdfInFits(asdf.AsdfFile):
+    def __init__(self, hdulist=None, tree=None, uri=None, extensions=None):
+        if hdulist is None:
+            hdulist = fits.HDUList()
+        super(AsdfInFits, self).__init__(tree=tree, uri=uri, extensions=extensions)
+        self._blocks = _EmbeddedBlockManager(hdulist, self)
+        self._hdulist = hdulist
+
+    @classmethod
+    def read(cls, hdulist, uri=None, validate_checksums=False, extensions=None):
+        try:
+            asdf_extension = hdulist[ASDF_EXTENSION_NAME]
+        except (KeyError, IndexError, AttributeError):
+            return cls(hdulist, uri=uri, extensions=extensions)
+
+        self = cls(hdulist, extensions=extensions)
+
+        buff = io.BytesIO(asdf_extension.data)
+
+        return cls._read_impl(self, buff, uri=uri, mode='r',
+                              validate_checksums=validate_checksums)
+
+    def _update_asdf_extension(self, all_array_storage=None,
+                               all_array_compression=None,
+                               auto_inline=None, pad_blocks=False):
+        buff = io.BytesIO()
+        super(AsdfInFits, self).write_to(
+            buff, all_array_storage=all_array_storage,
+            all_array_compression=all_array_compression,
+            auto_inline=auto_inline, pad_blocks=pad_blocks)
+        array = np.frombuffer(buff.getvalue(), np.uint8)
+
+        try:
+            asdf_extension = self._hdulist[ASDF_EXTENSION_NAME]
+        except (KeyError, IndexError, AttributeError):
+            self._hdulist.append(fits.ImageHDU(array, name=ASDF_EXTENSION_NAME))
+        else:
+            asdf_extension.data = array
+
+    def write_to(self, filename, all_array_storage=None,
+                 all_array_compression=None, auto_inline=None,
+                 pad_blocks=False):
+        self._update_asdf_extension(
+            all_array_storage=all_array_storage,
+            all_array_compression=all_array_compression,
+            auto_inline=auto_inline, pad_blocks=pad_blocks)
+
+        self._hdulist.writeto(filename)
+
+    def update(self, all_array_storage=None, all_array_compression=None,
+               auto_inline=None, pad_blocks=False):
+        self._update_asdf_extension(
+            all_array_storage=all_array_storage,
+            all_array_compression=all_array_compression,
+            auto_inline=auto_inline, pad_blocks=pad_blocks)
+
+    def write_to_stream(self, data):
+        raise NotImplementedError(
+            "Can not stream data to an ASDF file embedded in a FITS file")

--- a/pyasdf/fits_embed.py
+++ b/pyasdf/fits_embed.py
@@ -93,7 +93,7 @@ class AsdfInFits(asdf.AsdfFile):
         self._hdulist = hdulist
 
     @classmethod
-    def read(cls, hdulist, uri=None, validate_checksums=False, extensions=None):
+    def open(cls, hdulist, uri=None, validate_checksums=False, extensions=None):
         try:
             asdf_extension = hdulist[ASDF_EXTENSION_NAME]
         except (KeyError, IndexError, AttributeError):
@@ -103,7 +103,7 @@ class AsdfInFits(asdf.AsdfFile):
 
         buff = io.BytesIO(asdf_extension.data)
 
-        return cls._read_impl(self, buff, uri=uri, mode='r',
+        return cls._open_impl(self, buff, uri=uri, mode='r',
                               validate_checksums=validate_checksums)
 
     def _update_asdf_extension(self, all_array_storage=None,

--- a/pyasdf/tests/helpers.py
+++ b/pyasdf/tests/helpers.py
@@ -94,7 +94,8 @@ def assert_roundtrip_tree(
             asdf_check_func(ff)
 
     buff.seek(0)
-    content = AsdfFile.open(buff, _get_yaml_content=True)
+    ff = AsdfFile()
+    content = AsdfFile._open_impl(ff, buff, _get_yaml_content=True)
     buff.close()
     # We *never* want to get any raw python objects out
     assert b'!!python' not in content

--- a/pyasdf/tests/test_fits_embed.py
+++ b/pyasdf/tests/test_fits_embed.py
@@ -1,0 +1,51 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, unicode_literals, print_function
+
+import os
+
+import numpy as np
+
+from astropy.io import fits
+
+from .. import asdf
+from .. import fits_embed
+
+from .helpers import assert_tree_match
+
+
+def test_embed_asdf_in_fits_file(tmpdir):
+    hdulist = fits.HDUList()
+    hdulist.append(fits.ImageHDU(np.arange(512, dtype=np.float), name='SCI'))
+    hdulist.append(fits.ImageHDU(np.arange(512, dtype=np.float), name='DQ'))
+
+    tree = {
+        'model': {
+            'sci': {
+                'data': hdulist['SCI'].data,
+                'wcs': 'WCS info'
+            },
+            'dq': {
+                'data': hdulist['DQ'].data,
+                'wcs': 'WCS info'
+            }
+        }
+    }
+
+    with fits_embed.AsdfInFits(hdulist, tree) as ff:
+        ff.write_to(os.path.join(str(tmpdir), 'test.fits'))
+
+    with fits.open(os.path.join(str(tmpdir), 'test.fits')) as hdulist2:
+        assert len(hdulist2) == 3
+        assert [x.name for x in hdulist2] == ['SCI', 'DQ', 'ASDF']
+
+        ff2 = fits_embed.AsdfInFits.read(hdulist)
+
+        assert_tree_match(tree, ff2.tree)
+
+    with asdf.AsdfFile(tree) as ff:
+        ff.write_to('test.asdf')
+
+    with asdf.AsdfFile.read('test.asdf') as ff:
+        assert_tree_match(tree, ff.tree)

--- a/pyasdf/tests/test_fits_embed.py
+++ b/pyasdf/tests/test_fits_embed.py
@@ -42,7 +42,7 @@ def test_embed_asdf_in_fits_file(tmpdir):
     with fits.open(os.path.join(str(tmpdir), 'test.fits')) as hdulist2:
         assert len(hdulist2) == 3
         assert [x.name for x in hdulist2] == ['SCI', 'DQ', 'ASDF']
-        assert hdulist2['ASDF'].data.tostring().strip().endswith("...")
+        assert hdulist2['ASDF'].data.tostring().strip().endswith(b"...")
 
         with fits_embed.AsdfInFits.open(hdulist) as ff2:
             assert_tree_match(tree, ff2.tree)
@@ -86,7 +86,7 @@ def test_embed_asdf_in_fits_file_anonymous_extensions(tmpdir):
     with fits.open(os.path.join(str(tmpdir), 'test.fits')) as hdulist2:
         assert len(hdulist2) == 4
         assert [x.name for x in hdulist2] == ['PRIMARY', '', '', 'ASDF']
-        assert hdulist2['ASDF'].data.tostring().strip().endswith("...")
+        assert hdulist2['ASDF'].data.tostring().strip().endswith(b"...")
 
         with fits_embed.AsdfInFits.open(hdulist) as ff2:
             assert_tree_match(tree, ff2.tree)

--- a/pyasdf/tests/test_fits_embed.py
+++ b/pyasdf/tests/test_fits_embed.py
@@ -33,12 +33,60 @@ def test_embed_asdf_in_fits_file(tmpdir):
         }
     }
 
-    with fits_embed.AsdfInFits(hdulist, tree) as ff:
-        ff.write_to(os.path.join(str(tmpdir), 'test.fits'))
+    ff = fits_embed.AsdfInFits(hdulist, tree)
+    ff.write_to(os.path.join(str(tmpdir), 'test.fits'))
+
+    ff2 = asdf.AsdfFile(tree)
+    ff2.write_to(os.path.join(str(tmpdir), 'plain.asdf'))
 
     with fits.open(os.path.join(str(tmpdir), 'test.fits')) as hdulist2:
         assert len(hdulist2) == 3
         assert [x.name for x in hdulist2] == ['SCI', 'DQ', 'ASDF']
+        assert hdulist2['ASDF'].data.tostring().strip().endswith("...")
+
+        with fits_embed.AsdfInFits.open(hdulist) as ff2:
+            assert_tree_match(tree, ff2.tree)
+
+            ff = asdf.AsdfFile(ff2.tree)
+            ff.write_to('test.asdf')
+
+            with asdf.AsdfFile.open('test.asdf') as ff:
+                assert_tree_match(tree, ff.tree)
+
+
+def test_embed_asdf_in_fits_file_anonymous_extensions(tmpdir):
+    hdulist = fits.HDUList()
+    hdulist.append(fits.ImageHDU(np.arange(512, dtype=np.float)))
+    hdulist.append(fits.ImageHDU(np.arange(512, dtype=np.float)))
+    hdulist.append(fits.ImageHDU(np.arange(512, dtype=np.float)))
+
+    tree = {
+        'model': {
+            'sci': {
+                'data': hdulist[0].data,
+                'wcs': 'WCS info'
+            },
+            'dq': {
+                'data': hdulist[1].data,
+                'wcs': 'WCS info'
+            },
+            'err': {
+                'data': hdulist[1].data,
+                'wcs': 'WCS info'
+            }
+        }
+    }
+
+    ff = fits_embed.AsdfInFits(hdulist, tree)
+    ff.write_to(os.path.join(str(tmpdir), 'test.fits'))
+
+    ff2 = asdf.AsdfFile(tree)
+    ff2.write_to(os.path.join(str(tmpdir), 'plain.asdf'))
+
+    with fits.open(os.path.join(str(tmpdir), 'test.fits')) as hdulist2:
+        assert len(hdulist2) == 4
+        assert [x.name for x in hdulist2] == ['PRIMARY', '', '', 'ASDF']
+        assert hdulist2['ASDF'].data.tostring().strip().endswith("...")
 
         with fits_embed.AsdfInFits.open(hdulist) as ff2:
             assert_tree_match(tree, ff2.tree)

--- a/pyasdf/tests/test_fits_embed.py
+++ b/pyasdf/tests/test_fits_embed.py
@@ -40,12 +40,11 @@ def test_embed_asdf_in_fits_file(tmpdir):
         assert len(hdulist2) == 3
         assert [x.name for x in hdulist2] == ['SCI', 'DQ', 'ASDF']
 
-        ff2 = fits_embed.AsdfInFits.read(hdulist)
+        with fits_embed.AsdfInFits.open(hdulist) as ff2:
+            assert_tree_match(tree, ff2.tree)
 
-        assert_tree_match(tree, ff2.tree)
-
-        with asdf.AsdfFile(ff2.tree) as ff:
+            ff = asdf.AsdfFile(ff2.tree)
             ff.write_to('test.asdf')
 
-        with asdf.AsdfFile.read('test.asdf') as ff:
-            assert_tree_match(tree, ff.tree)
+            with asdf.AsdfFile.open('test.asdf') as ff:
+                assert_tree_match(tree, ff.tree)

--- a/pyasdf/tests/test_fits_embed.py
+++ b/pyasdf/tests/test_fits_embed.py
@@ -44,8 +44,8 @@ def test_embed_asdf_in_fits_file(tmpdir):
 
         assert_tree_match(tree, ff2.tree)
 
-    with asdf.AsdfFile(tree) as ff:
-        ff.write_to('test.asdf')
+        with asdf.AsdfFile(ff2.tree) as ff:
+            ff.write_to('test.asdf')
 
-    with asdf.AsdfFile.read('test.asdf') as ff:
-        assert_tree_match(tree, ff.tree)
+        with asdf.AsdfFile.read('test.asdf') as ff:
+            assert_tree_match(tree, ff.tree)

--- a/pyasdf/tests/test_reference.py
+++ b/pyasdf/tests/test_reference.py
@@ -246,5 +246,6 @@ def test_internal_reference():
     buff = io.BytesIO()
     ff.write_to(buff)
     buff.seek(0)
-    content = asdf.AsdfFile().open(buff, _get_yaml_content=True)
+    ff = asdf.AsdfFile()
+    content = asdf.AsdfFile()._open_impl(ff, buff, _get_yaml_content=True)
     assert b"{$ref: ''}" in content


### PR DESCRIPTION
This saves an ASDF file as an extra "ASDF" extension inside of a FITS file.  That ASDF file can refer to binary arrays in other extensions in the FITS file.