### PR TITLE
Automatically fill-in default values

### DIFF
--- a/pyasdf/block.py
+++ b/pyasdf/block.py
@@ -318,7 +318,8 @@ class BlockManager(object):
                 raise ValueError("Block '{0}' not found.".format(source))
 
         elif isinstance(source, six.string_types):
-            asdffile = self._asdffile().read_external(source)
+            asdffile = self._asdffile().read_external(
+                source, do_not_fill_defaults=True)
             block = asdffile.blocks._blocks[0]
             block.array_storage = 'external'
             if block not in self._blocks:

--- a/pyasdf/reference.py
+++ b/pyasdf/reference.py
@@ -61,9 +61,10 @@ class Reference(AsdfType):
             self._asdffile = weakref.ref(asdffile)
         self._target = target
 
-    def _get_target(self):
+    def _get_target(self, do_not_fill_defaults=False):
         if self._target is None:
-            asdffile = self._asdffile().read_external(self._uri)
+            asdffile = self._asdffile().read_external(
+                self._uri, do_not_fill_defaults=do_not_fill_defaults)
             parts = urlparse.urlparse(self._uri)
             fragment = parts.fragment
             self._target = resolve_fragment(asdffile.tree, fragment)
@@ -100,8 +101,8 @@ class Reference(AsdfType):
     def __array__(self):
         return np.asarray(self._get_target())
 
-    def __call__(self):
-        return self._get_target()
+    def __call__(self, do_not_fill_defaults=False):
+        return self._get_target(do_not_fill_defaults=do_not_fill_defaults)
 
     @classmethod
     def to_tree(self, data, ctx):
@@ -129,14 +130,14 @@ def find_references(tree, ctx):
     return treeutil.walk_and_modify(tree, do_find)
 
 
-def resolve_references(tree, ctx):
+def resolve_references(tree, ctx, do_not_fill_defaults=False):
     """
     Resolve all of the references in the tree, by loading the external
     data and inserting it directly into the tree.
     """
     def do_resolve(tree):
         if isinstance(tree, Reference):
-            return tree()
+            return tree(do_not_fill_defaults=do_not_fill_defaults)
 
         return tree
 

--- a/pyasdf/tags/transform/tests/test_transform.py
+++ b/pyasdf/tags/transform/tests/test_transform.py
@@ -63,7 +63,8 @@ def test_name(tmpdir):
 def test_domain(tmpdir):
     def check(ff):
         assert ff.tree['rot'].meta['domain'] == {
-            'lower': 0, 'upper': 1, 'includes_lower': True}
+            'lower': 0, 'upper': 1, 'includes_lower': True,
+            'includes_upper': False}
 
     model = astmodels.Rotation2D(23)
     model.meta['domain'] = {'lower': 0, 'upper': 1, 'includes_lower': True}

--- a/pyasdf/tests/data/custom.yaml
+++ b/pyasdf/tests/data/custom.yaml
@@ -3,3 +3,4 @@
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
 id: "http://nowhere.org/schemas/custom/1.0.0/custom"
 type: integer
+default: 42

--- a/pyasdf/tests/test_schema.py
+++ b/pyasdf/tests/test_schema.py
@@ -71,6 +71,7 @@ def test_validate_all_schema():
     def validate_schema(path):
         with open(path, 'rb') as fd:
             schema_tree = yaml.load(fd)
+
         schema.check_schema(schema_tree)
 
     src = os.path.join(os.path.dirname(__file__), '../schemas')
@@ -285,3 +286,89 @@ def test_invalid_schema():
     s = {'type': 'foobar'}
     with pytest.raises(ValidationError):
         schema.check_schema(s)
+
+
+def test_defaults():
+    s = {
+        'type': 'object',
+        'properties': {
+            'a': {
+                'type': 'integer',
+                'default': 42
+            }
+        }
+    }
+
+    t = {}
+
+    cls = schema._create_validator(schema.FILL_DEFAULTS)
+    validator = cls(s)
+    validator.validate(t, _schema=s)
+
+    assert t['a'] == 42
+
+    cls = schema._create_validator(schema.REMOVE_DEFAULTS)
+    validator = cls(s)
+    validator.validate(t, _schema=s)
+
+    assert t == {}
+
+
+def test_default_check_in_schema():
+    s = {
+        'type': 'object',
+        'properties': {
+            'a': {
+                'type': 'integer',
+                'default': 'foo'
+            }
+        }
+    }
+
+    with pytest.raises(ValidationError):
+        schema.check_schema(s)
+
+
+def test_fill_and_remove_defaults():
+    class CustomType(str, asdftypes.AsdfType):
+        name = 'custom_type'
+        organization = 'nowhere.org'
+        version = (1, 0, 0)
+        standard = 'custom'
+
+    class CustomExtension:
+        @property
+        def types(self):
+            return [CustomType]
+
+        @property
+        def tag_mapping(self):
+            return [('tag:nowhere.org:custom',
+                     'http://nowhere.org/schemas/custom{tag_suffix}')]
+
+        @property
+        def url_mapping(self):
+            return [('http://nowhere.org/schemas/custom/1.0.0/',
+                     urljoin('file:', pathname2url(os.path.join(
+                         TEST_DATA_PATH))) + '/{url_suffix}.yaml')]
+
+    yaml = """
+custom: !<tag:nowhere.org:custom/1.0.0/custom>
+  b: 10
+    """
+    buff = helpers.yaml_to_asdf(yaml)
+    with pytest.raises(ValidationError):
+        ff = asdf.AsdfFile.read(buff, extensions=[CustomExtension()])
+        assert 'a' in ff.tree['custom']
+        assert ff.tree['custom']['a'] == 42
+
+    buff.seek(0)
+    with pytest.raises(ValidationError):
+        ff = asdf.AsdfFile.read(buff, extensions=[CustomExtension()],
+                                do_not_fill_defaults=True)
+        assert 'a' not in ff.tree['custom']
+        ff.fill_defaults()
+        assert 'a' in ff.tree['custom']
+        assert ff.tree['custom']['a'] == 42
+        ff.remove_defaults()
+        assert 'a' not in ff.tree['custom']

--- a/pyasdf/tests/test_schema.py
+++ b/pyasdf/tests/test_schema.py
@@ -31,6 +31,24 @@ from . import helpers
 TEST_DATA_PATH = os.path.join(os.path.dirname(__file__), 'data')
 
 
+class CustomExtension:
+    @property
+    def types(self):
+        return []
+
+    @property
+    def tag_mapping(self):
+        return [('tag:nowhere.org:custom',
+                 'http://nowhere.org/schemas/custom{tag_suffix}')]
+
+    @property
+    def url_mapping(self):
+        return [('http://nowhere.org/schemas/custom/1.0.0/',
+                 urljoin('file:', pathname2url(os.path.join(
+                     TEST_DATA_PATH))) + '/{url_suffix}.yaml')]
+
+
+
 def test_violate_toplevel_schema():
     tree = {'fits': 'This does not look like a FITS file'}
 
@@ -149,21 +167,10 @@ def test_flow_style():
         version = (1, 0, 0)
         standard = 'custom'
 
-    class CustomFlowStyleExtension:
+    class CustomFlowStyleExtension(CustomExtension):
         @property
         def types(self):
             return [CustomFlowStyleType]
-
-        @property
-        def tag_mapping(self):
-            return [('tag:nowhere.org:custom',
-                     'http://nowhere.org/schemas/custom{tag_suffix}')]
-
-        @property
-        def url_mapping(self):
-            return [('http://nowhere.org/schemas/custom/1.0.0/',
-                     urljoin('file:', pathname2url(os.path.join(
-                         TEST_DATA_PATH))) + '/{url_suffix}.yaml')]
 
     tree = {
         'custom_flow': CustomFlowStyleType({'a': 42, 'b': 43})
@@ -184,21 +191,10 @@ def test_style():
         version = (1, 0, 0)
         standard = 'custom'
 
-    class CustomStyleExtension:
+    class CustomStyleExtension(CustomExtension):
         @property
         def types(self):
             return [CustomStyleType]
-
-        @property
-        def tag_mapping(self):
-            return [('tag:nowhere.org:custom',
-                     'http://nowhere.org/schemas/custom{tag_suffix}')]
-
-        @property
-        def url_mapping(self):
-            return [('http://nowhere.org/schemas/custom/1.0.0/',
-                     urljoin('file:', pathname2url(os.path.join(
-                         TEST_DATA_PATH))) + '/{url_suffix}.yaml')]
 
     tree = {
         'custom_style': CustomStyleType("short")
@@ -239,21 +235,10 @@ def test_invalid_nested():
         version = (1, 0, 0)
         standard = 'custom'
 
-    class CustomExtension:
+    class CustomTypeExtension(CustomExtension):
         @property
         def types(self):
             return [CustomType]
-
-        @property
-        def tag_mapping(self):
-            return [('tag:nowhere.org:custom',
-                     'http://nowhere.org/schemas/custom{tag_suffix}')]
-
-        @property
-        def url_mapping(self):
-            return [('http://nowhere.org/schemas/custom/1.0.0/',
-                     urljoin('file:', pathname2url(os.path.join(
-                         TEST_DATA_PATH))) + '/{url_suffix}.yaml')]
 
     yaml = """
 custom: !<tag:nowhere.org:custom/1.0.0/custom>
@@ -264,7 +249,7 @@ custom: !<tag:nowhere.org:custom/1.0.0/custom>
 
     buff.seek(0)
     with pytest.raises(ValidationError):
-        ff = asdf.AsdfFile.read(buff, extensions=[CustomExtension()])
+        ff = asdf.AsdfFile.read(buff, extensions=[CustomTypeExtension()])
 
     # Make sure tags get validated inside of other tags that know
     # nothing about them.
@@ -276,7 +261,7 @@ array: !core/ndarray
     """
     buff = helpers.yaml_to_asdf(yaml)
     with pytest.raises(ValidationError):
-        ff = asdf.AsdfFile.read(buff, extensions=[CustomExtension()])
+        ff = asdf.AsdfFile.read(buff, extensions=[CustomTypeExtension()])
 
 
 def test_invalid_schema():
@@ -336,21 +321,10 @@ def test_fill_and_remove_defaults():
         version = (1, 0, 0)
         standard = 'custom'
 
-    class CustomExtension:
+    class CustomTypeExtension(CustomExtension):
         @property
         def types(self):
             return [CustomType]
-
-        @property
-        def tag_mapping(self):
-            return [('tag:nowhere.org:custom',
-                     'http://nowhere.org/schemas/custom{tag_suffix}')]
-
-        @property
-        def url_mapping(self):
-            return [('http://nowhere.org/schemas/custom/1.0.0/',
-                     urljoin('file:', pathname2url(os.path.join(
-                         TEST_DATA_PATH))) + '/{url_suffix}.yaml')]
 
     yaml = """
 custom: !<tag:nowhere.org:custom/1.0.0/custom>
@@ -358,13 +332,13 @@ custom: !<tag:nowhere.org:custom/1.0.0/custom>
     """
     buff = helpers.yaml_to_asdf(yaml)
     with pytest.raises(ValidationError):
-        ff = asdf.AsdfFile.read(buff, extensions=[CustomExtension()])
+        ff = asdf.AsdfFile.read(buff, extensions=[CustomTypeExtension()])
         assert 'a' in ff.tree['custom']
         assert ff.tree['custom']['a'] == 42
 
     buff.seek(0)
     with pytest.raises(ValidationError):
-        ff = asdf.AsdfFile.read(buff, extensions=[CustomExtension()],
+        ff = asdf.AsdfFile.read(buff, extensions=[CustomTypeExtension()],
                                 do_not_fill_defaults=True)
         assert 'a' not in ff.tree['custom']
         ff.fill_defaults()

--- a/pyasdf/util.py
+++ b/pyasdf/util.py
@@ -203,3 +203,14 @@ class BinaryStruct(object):
         for ((offset, datatype), val) in updates:
             fd.seek(start + offset)
             fd.write(struct.pack(datatype, val))
+
+
+class HashableDict(dict):
+    """
+    A simple wrapper around dict to make it hashable.
+
+    This is sure to be slow, but for small dictionaries it shouldn't
+    matter.
+    """
+    def __hash__(self):
+        return hash(frozenset(self.items()))

--- a/pyasdf/yamlutil.py
+++ b/pyasdf/yamlutil.py
@@ -245,7 +245,7 @@ def tagged_tree_to_custom_tree(tree, ctx):
     return treeutil.walk_and_modify(tree, walker)
 
 
-def load_tree(yaml_content, ctx):
+def load_tree(yaml_content, ctx, do_not_fill_defaults=False):
     """
     Load YAML, returning a tree of objects and custom types.
 
@@ -264,6 +264,8 @@ def load_tree(yaml_content, ctx):
     tree = yaml.load(yaml_content, Loader=AsdfLoaderTmp)
     tree = reference.find_references(tree, ctx)
     schema.validate(tree, ctx)
+    if not do_not_fill_defaults:
+        schema.fill_defaults(tree, ctx)
     tree = tagged_tree_to_custom_tree(tree, ctx)
     return tree
 
@@ -296,6 +298,7 @@ def dump_tree(tree, fd, ctx):
 
     tree = custom_tree_to_tagged_tree(tree, ctx)
     schema.validate(tree, ctx)
+    schema.remove_defaults(tree, ctx)
 
     yaml.dump_all(
         [tree], stream=fd, Dumper=AsdfDumperTmp,


### PR DESCRIPTION
Also updates the schema checker to make sure the default values in the schema are valid in their own context.