### PR TITLE
Example failing on MacOS X

### DIFF
--- a/pyasdf/generic_io.py
+++ b/pyasdf/generic_io.py
@@ -111,7 +111,7 @@ if sys.platform == 'darwin':
         OSX_WRITE_LIMIT = 2 ** 32
         if fd is None or array.nbytes >= OSX_WRITE_LIMIT and array.nbytes % 4096 == 0:
             return _array_tofile_chunked(write, array, OSX_WRITE_LIMIT)
-        return _array_tofile_simple(fd, array)
+        return _array_tofile_simple(fd, write, array)
 elif sys.platform.startswith('win'):
     def _array_tofile(fd, write, array):
         WIN_WRITE_LIMIT = 2 ** 30


### PR DESCRIPTION
I tried running the following example:

```python
from pyasdf import AsdfFile
import numpy as np

tree = {
  'author': 'John Doe',
  'my_array': np.random.rand(8, 8)
}
ff = AsdfFile(tree)
with ff.write_to("example.asdf"):
    pass
```

and I get the following exception:

```
Traceback (most recent call last):
  File "test.py", line 25, in <module>
    with ff.write_to("example.asdf"):
  File "/Users/tom/miniconda3/envs/production/lib/python3.4/site-packages/pyasdf-0.0.dev425-py3.4.egg/pyasdf/asdf.py", line 609, in write_to
    self._serial_write(fd, pad_blocks)
  File "/Users/tom/miniconda3/envs/production/lib/python3.4/site-packages/pyasdf-0.0.dev425-py3.4.egg/pyasdf/asdf.py", line 428, in _serial_write
    self.blocks.write_internal_blocks_serial(fd, pad_blocks)
  File "/Users/tom/miniconda3/envs/production/lib/python3.4/site-packages/pyasdf-0.0.dev425-py3.4.egg/pyasdf/block.py", line 137, in write_internal_blocks_serial
    block.write(fd)
  File "/Users/tom/miniconda3/envs/production/lib/python3.4/site-packages/pyasdf-0.0.dev425-py3.4.egg/pyasdf/block.py", line 758, in write
    fd.write_array(self._data)
  File "/Users/tom/miniconda3/envs/production/lib/python3.4/site-packages/pyasdf-0.0.dev425-py3.4.egg/pyasdf/generic_io.py", line 594, in write_array
    _array_tofile(self._fd, self._fd.write, arr)
  File "/Users/tom/miniconda3/envs/production/lib/python3.4/site-packages/pyasdf-0.0.dev425-py3.4.egg/pyasdf/generic_io.py", line 114, in _array_tofile
    return _array_tofile_simple(fd, array)
TypeError: _array_tofile_simple() missing 1 required positional argument: 'array'
```

I am using Python 3.4 on OSX
