### PR TITLE
Make it clear from repr/str when unloaded array is masked

### DIFF
--- a/pyasdf/tags/core/ndarray.py
+++ b/pyasdf/tags/core/ndarray.py
@@ -239,14 +239,16 @@ class NDArrayType(AsdfType):
     def __repr__(self):
         # repr alone should not force loading of the data
         if self._array is None:
-            return "<array (unloaded) shape: {0} dtype: {1}>".format(
+            return "<{0} (unloaded) shape: {1} dtype: {2}>".format(
+                'array' if self._mask is None else 'masked array',
                 self._shape, self._dtype)
         return repr(self._array)
 
     def __str__(self):
         # str alone should not force loading of the data
         if self._array is None:
-            return "<array (unloaded) shape: {0} dtype: {1}>".format(
+            return "<{0} (unloaded) shape: {1} dtype: {2}>".format(
+                'array' if self._mask is None else 'masked array',
                 self._shape, self._dtype)
         return str(self._array)
 


### PR DESCRIPTION
Before this change, it was not easy to know if an unloaded array was masked or not, and this now outputs:

```
<masked_array (unloaded) shape: [3] dtype: int64>
```

I'd be happy to add a test but I wasn't sure where this should be done?