### PR TITLE
Simplify write_to and context manager usage.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,8 +39,7 @@ transparently:
      'my_array': np.random.rand(8, 8)
    }
    ff = AsdfFile(tree)
-   with ff.write_to("example.asdf"):
-       pass
+   ff.write_to("example.asdf")
 
 .. asdf:: example.asdf
 

--- a/docs/sphinxext/example.py
+++ b/docs/sphinxext/example.py
@@ -74,48 +74,48 @@ class AsdfDirective(Directive):
 
         parts = []
         try:
-            code = AsdfFile.read(filename, _get_yaml_content=True)
+            code = AsdfFile.open(filename, _get_yaml_content=True)
             code = '{0}{1}\n'.format(ASDF_MAGIC, version_string) + code.strip().decode('utf-8')
             literal = nodes.literal_block(code, code)
             literal['language'] = 'yaml'
             set_source_info(self, literal)
             parts.append(literal)
 
-            ff = AsdfFile.read(filename)
-            for i, block in enumerate(ff.blocks.internal_blocks):
-                data = codecs.encode(block.data.tostring(), 'hex')
-                if len(data) > 40:
-                    data = data[:40] + '...'.encode()
-                allocated = block._allocated
-                size = block._size
-                data_size = block._data_size
-                flags = block._flags
+            with AsdfFile.open(filename) as ff:
+                for i, block in enumerate(ff.blocks.internal_blocks):
+                    data = codecs.encode(block.data.tostring(), 'hex')
+                    if len(data) > 40:
+                        data = data[:40] + '...'.encode()
+                    allocated = block._allocated
+                    size = block._size
+                    data_size = block._data_size
+                    flags = block._flags
 
-                if flags & BLOCK_FLAG_STREAMED:
-                    allocated = size = data_size = 0
+                    if flags & BLOCK_FLAG_STREAMED:
+                        allocated = size = data_size = 0
 
-                lines = []
-                lines.append('BLOCK {0}:'.format(i))
+                    lines = []
+                    lines.append('BLOCK {0}:'.format(i))
 
-                human_flags = []
-                for key, val in FLAGS.items():
-                    if flags & key:
-                        human_flags.append(val)
-                if len(human_flags):
-                    lines.append('    flags: {0}'.format(' | '.join(human_flags)))
-                if block.compression:
-                    lines.append('    compression: {0}'.format(block.compression))
-                lines.append('    allocated_size: {0}'.format(allocated))
-                lines.append('    used_size: {0}'.format(size))
-                lines.append('    data_size: {0}'.format(data_size))
-                lines.append('    data: {0}'.format(data))
+                    human_flags = []
+                    for key, val in FLAGS.items():
+                        if flags & key:
+                            human_flags.append(val)
+                    if len(human_flags):
+                        lines.append('    flags: {0}'.format(' | '.join(human_flags)))
+                    if block.compression:
+                        lines.append('    compression: {0}'.format(block.compression))
+                    lines.append('    allocated_size: {0}'.format(allocated))
+                    lines.append('    used_size: {0}'.format(size))
+                    lines.append('    data_size: {0}'.format(data_size))
+                    lines.append('    data: {0}'.format(data))
 
-                code = '\n'.join(lines)
+                    code = '\n'.join(lines)
 
-                literal = nodes.literal_block(code, code)
-                literal['language'] = 'yaml'
-                set_source_info(self, literal)
-                parts.append(literal)
+                    literal = nodes.literal_block(code, code)
+                    literal['language'] = 'yaml'
+                    set_source_info(self, literal)
+                    parts.append(literal)
 
         finally:
             os.chdir(cwd)

--- a/pyasdf/__init__.py
+++ b/pyasdf/__init__.py
@@ -50,4 +50,4 @@ if _ASTROPY_SETUP_ is False:
     class ValidationError(ValidationError):
         pass
 
-    open = AsdfFile.read
+    open = AsdfFile.open

--- a/pyasdf/commands/defragment.py
+++ b/pyasdf/commands/defragment.py
@@ -66,11 +66,11 @@ def defragment(input, output=None, resolve_references=False, compress=None):
     compress : str, optional
         Compression to use.
     """
-    with AsdfFile.read(input) as ff:
+    with AsdfFile.open(input) as ff:
         ff2 = AsdfFile(ff)
         if resolve_references:
             ff2.resolve_references()
-        with ff2.write_to(output,
-                          all_array_storage='internal',
-                          all_array_compression=compress):
-            pass
+        ff2.write_to(
+            output,
+            all_array_storage='internal',
+            all_array_compression=compress)

--- a/pyasdf/commands/exploded.py
+++ b/pyasdf/commands/exploded.py
@@ -66,12 +66,11 @@ def implode(input, output=None, resolve_references=False):
     if output is None:
         base, ext = os.path.splitext(input)
         output = base + '_all' + '.asdf'
-    with AsdfFile.read(input) as ff:
+    with AsdfFile.open(input) as ff:
         ff2 = AsdfFile(ff)
         if resolve_references:
             ff2.resolve_references()
-        with ff2.write_to(output, all_array_storage='internal'):
-            pass
+        ff2.write_to(output, all_array_storage='internal')
 
 
 class Explode(Command):
@@ -117,6 +116,5 @@ def explode(input, output=None):
     if output is None:
         base, ext = os.path.splitext(input)
         output = base + '_exploded' + '.asdf'
-    with AsdfFile.read(input) as ff:
-        with AsdfFile(ff).write_to(output, all_array_storage='external'):
-            pass
+    with AsdfFile.open(input) as ff:
+        ff.write_to(output, all_array_storage='external')

--- a/pyasdf/commands/tests/test_defragment.py
+++ b/pyasdf/commands/tests/test_defragment.py
@@ -24,9 +24,9 @@ def test_to_yaml(tmpdir):
 
     path = os.path.join(str(tmpdir), 'original.asdf')
     out_path = os.path.join(str(tmpdir), 'original.defragment.asdf')
-    with AsdfFile(tree) as ff:
-        ff.write_to(path)
-        assert len(ff.blocks) == 2
+    ff = AsdfFile(tree)
+    ff.write_to(path)
+    assert len(ff.blocks) == 2
 
     result = main.main_from_args(
         ['defragment', path, '-o', out_path, '-c', 'zlib'])
@@ -40,6 +40,6 @@ def test_to_yaml(tmpdir):
 
     assert files['original.defragment.asdf'] < files['original.asdf']
 
-    ff = AsdfFile.read(os.path.join(str(tmpdir), 'original.defragment.asdf'))
-    assert_tree_match(ff.tree, tree)
-    assert len(list(ff.blocks.internal_blocks)) == 2
+    with AsdfFile.open(os.path.join(str(tmpdir), 'original.defragment.asdf')) as ff:
+        assert_tree_match(ff.tree, tree)
+        assert len(list(ff.blocks.internal_blocks)) == 2

--- a/pyasdf/commands/tests/test_exploded.py
+++ b/pyasdf/commands/tests/test_exploded.py
@@ -23,9 +23,9 @@ def test_explode_then_implode(tmpdir):
         }
 
     path = os.path.join(str(tmpdir), 'original.asdf')
-    with AsdfFile(tree) as ff:
-        ff.write_to(path)
-        assert len(ff.blocks) == 2
+    ff = AsdfFile(tree)
+    ff.write_to(path)
+    assert len(ff.blocks) == 2
 
     result = main.main_from_args(['explode', path])
 

--- a/pyasdf/commands/tests/test_to_yaml.py
+++ b/pyasdf/commands/tests/test_to_yaml.py
@@ -23,9 +23,9 @@ def test_to_yaml(tmpdir):
         }
 
     path = os.path.join(str(tmpdir), 'original.asdf')
-    with AsdfFile(tree) as ff:
-        ff.write_to(path)
-        assert len(ff.blocks) == 2
+    ff = AsdfFile(tree)
+    ff.write_to(path)
+    assert len(ff.blocks) == 2
 
     result = main.main_from_args(['to_yaml', path])
 
@@ -36,6 +36,6 @@ def test_to_yaml(tmpdir):
     assert 'original.asdf' in files
     assert 'original.yaml' in files
 
-    ff = AsdfFile.read(os.path.join(str(tmpdir), 'original.yaml'))
-    assert_tree_match(ff.tree, tree)
-    assert len(list(ff.blocks.internal_blocks)) == 0
+    with AsdfFile.open(os.path.join(str(tmpdir), 'original.yaml')) as ff:
+        assert_tree_match(ff.tree, tree)
+        assert len(list(ff.blocks.internal_blocks)) == 0

--- a/pyasdf/commands/to_yaml.py
+++ b/pyasdf/commands/to_yaml.py
@@ -64,9 +64,8 @@ def to_yaml(input, output=None, resolve_references=False):
     if output is None:
         base, ext = os.path.splitext(input)
         output = base + '.yaml'
-    with AsdfFile.read(input) as ff:
+    with AsdfFile.open(input) as ff:
         ff2 = AsdfFile(ff)
         if resolve_references:
             ff2.resolve_references()
-        with ff2.write_to(output, all_array_storage='inline'):
-            pass
+        ff2.write_to(output, all_array_storage='inline')

--- a/pyasdf/generic_io.py
+++ b/pyasdf/generic_io.py
@@ -494,9 +494,6 @@ class GenericFile(object):
         buff = self.read(size)
         return np.frombuffer(buff, np.uint8, size, 0)
 
-    def finalize(self):
-        return self
-
 
 class GenericWrapper(object):
     """
@@ -579,7 +576,7 @@ class RealFile(RandomAccessFile):
     """
     Handles "real" files on a filesystem.
     """
-    def __init__(self, fd, mode, close=True, uri=None):
+    def __init__(self, fd, mode, close=False, uri=None):
         super(RealFile, self).__init__(fd, mode, close=close, uri=uri)
         stat = os.fstat(fd.fileno())
         if sys.platform.startswith('win'):
@@ -616,15 +613,6 @@ class RealFile(RandomAccessFile):
 
     def read_into_array(self, size):
         return _array_fromfile(self._fd, size)
-
-    def finalize(self):
-        if isinstance(self._fd, atomicfile._AtomicWFile):
-            tell = self._fd.tell()
-            self._fd.close()
-            new_fd = get_file(self._fd.name, 'rw')
-            new_fd.seek(tell)
-            return new_fd
-        return self
 
 
 class MemoryIO(RandomAccessFile):

--- a/pyasdf/reference.py
+++ b/pyasdf/reference.py
@@ -63,7 +63,7 @@ class Reference(AsdfType):
 
     def _get_target(self, do_not_fill_defaults=False):
         if self._target is None:
-            asdffile = self._asdffile().read_external(
+            asdffile = self._asdffile().open_external(
                 self._uri, do_not_fill_defaults=do_not_fill_defaults)
             parts = urlparse.urlparse(self._uri)
             fragment = parts.fragment

--- a/pyasdf/stream.py
+++ b/pyasdf/stream.py
@@ -19,9 +19,10 @@ class Stream(ndarray.NDArrayType):
          >>> import numpy as np
          >>> ff = AsdfFile()
          >>> ff.tree['streamed'] = Stream([1024], np.float64)
-         >>> with ff.write_to('test.asdf') as ff:
+         >>> with open('test.asdf', 'wb') as fd:
+         ...     ff.write_to(fd)
          ...     for i in range(200):
-         ...         ff.write_to_stream(np.array([i] * 1024, np.float64).tostring())
+         ...         fd.write(np.array([i] * 1024, np.float64).tostring())
     """
 
     types = []

--- a/pyasdf/stream.py
+++ b/pyasdf/stream.py
@@ -22,7 +22,8 @@ class Stream(ndarray.NDArrayType):
          >>> with open('test.asdf', 'wb') as fd:
          ...     ff.write_to(fd)
          ...     for i in range(200):
-         ...         fd.write(np.array([i] * 1024, np.float64).tostring())
+         ...         nbytes = fd.write(
+         ...                      np.array([i] * 1024, np.float64).tostring())
     """
 
     types = []

--- a/pyasdf/tags/core/tests/test_complex.py
+++ b/pyasdf/tags/core/tests/test_complex.py
@@ -18,7 +18,8 @@ a: !core/complex
 
     buff = helpers.yaml_to_asdf(yaml)
     with pytest.raises(ValueError):
-        asdf.AsdfFile.read(buff)
+        with asdf.AsdfFile.open(buff):
+            pass
 
 
 def test_roundtrip(tmpdir):

--- a/pyasdf/tags/core/tests/test_ndarray.py
+++ b/pyasdf/tags/core/tests/test_ndarray.py
@@ -399,8 +399,7 @@ def test_masked_array_repr(tmpdir):
         'masked': np.ma.array([1, 2, 3], mask=[False, True, False])
     }
 
-    with asdf.AsdfFile(tree).write_to(tmppath):
-        pass
+    asdf.AsdfFile(tree).write_to(tmppath)
 
-    with asdf.AsdfFile.read(tmppath) as ff:
+    with asdf.AsdfFile.open(tmppath) as ff:
         assert 'masked array' in repr(ff.tree['masked'])

--- a/pyasdf/tags/core/tests/test_ndarray.py
+++ b/pyasdf/tags/core/tests/test_ndarray.py
@@ -106,16 +106,15 @@ def test_dont_load_data():
     ff.write_to(buff)
 
     buff.seek(0)
-    ff = asdf.AsdfFile.read(buff)
+    with asdf.AsdfFile.open(buff) as ff:
+        ff.run_hook('pre_write')
 
-    ff.run_hook('pre_write')
+        # repr and str shouldn't load data
+        str(ff.tree['science_data'])
+        repr(ff.tree)
 
-    # repr and str shouldn't load data
-    str(ff.tree['science_data'])
-    repr(ff.tree)
-
-    for block in ff.blocks.internal_blocks:
-        assert block._data is None
+        for block in ff.blocks.internal_blocks:
+            assert block._data is None
 
 
 def test_table_inline(tmpdir):
@@ -221,17 +220,16 @@ def test_inline():
 
     buff = io.BytesIO()
 
-    with asdf.AsdfFile(tree) as ff:
-        ff.blocks[tree['science_data']].array_storage = 'inline'
-        ff.write_to(buff)
+    ff = asdf.AsdfFile(tree)
+    ff.blocks[tree['science_data']].array_storage = 'inline'
+    ff.write_to(buff)
 
     buff.seek(0)
-    with asdf.AsdfFile.read(buff, mode='rw') as ff:
+    with asdf.AsdfFile.open(buff, mode='rw') as ff:
         helpers.assert_tree_match(tree, ff.tree)
         assert len(list(ff.blocks.internal_blocks)) == 0
         buff = io.BytesIO()
-        with asdf.AsdfFile(ff).write_to(buff):
-            pass
+        ff.write_to(buff)
 
     assert b'[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]' in buff.getvalue()
 
@@ -240,9 +238,8 @@ def test_inline_bare():
     content = "arr: !core/ndarray [[1, 2, 3, 4], [5, 6, 7, 8]]"
     buff = helpers.yaml_to_asdf(content)
 
-    ff = asdf.AsdfFile.read(buff)
-
-    assert_array_equal(ff.tree['arr'], [[1, 2, 3, 4], [5, 6, 7, 8]])
+    with asdf.AsdfFile.open(buff) as ff:
+        assert_array_equal(ff.tree['arr'], [[1, 2, 3, 4], [5, 6, 7, 8]])
 
 
 def test_mask_roundtrip(tmpdir):
@@ -275,11 +272,10 @@ def test_mask_nan():
     """
 
     buff = helpers.yaml_to_asdf(content)
-    ff = asdf.AsdfFile.read(buff)
-
-    assert_array_equal(
-        ff.tree['arr'].mask,
-        [[False, False, False, True], [False, False, False, False]])
+    with asdf.AsdfFile.open(buff) as ff:
+        assert_array_equal(
+            ff.tree['arr'].mask,
+            [[False, False, False, True], [False, False, False, False]])
 
 
 def test_string(tmpdir):
@@ -303,9 +299,8 @@ def test_inline_string():
     content = "arr: !core/ndarray ['a', 'b', 'c']"
     buff = helpers.yaml_to_asdf(content)
 
-    ff = asdf.AsdfFile.read(buff)
-
-    assert_array_equal(ff.tree['arr']._make_array(), ['a', 'b', 'c'])
+    with asdf.AsdfFile.open(buff) as ff:
+        assert_array_equal(ff.tree['arr']._make_array(), ['a', 'b', 'c'])
 
 
 def test_inline_structured():
@@ -319,9 +314,8 @@ def test_inline_structured():
 
     buff = helpers.yaml_to_asdf(content)
 
-    ff = asdf.AsdfFile.read(buff)
-
-    assert ff.tree['arr']['f1'].dtype.char == 'H'
+    with asdf.AsdfFile.open(buff) as ff:
+        assert ff.tree['arr']['f1'].dtype.char == 'H'
 
 
 def test_simple_table():
@@ -359,10 +353,9 @@ def test_unicode_to_list(tmpdir):
     ff.write_to(fd)
     fd.seek(0)
 
-    with asdf.AsdfFile.read(fd) as ff:
+    with asdf.AsdfFile.open(fd) as ff:
         ff.resolve_and_inline()
-        with ff.write_to(io.BytesIO()):
-            pass
+        ff.write_to(io.BytesIO())
 
 
 def test_inline_masked_array(tmpdir):
@@ -370,10 +363,9 @@ def test_inline_masked_array(tmpdir):
 
     f = asdf.AsdfFile(tree)
     f.set_array_storage(tree['test'], 'inline')
-    with f.write_to('masked.asdf'):
-        pass
+    f.write_to('masked.asdf')
 
-    with asdf.AsdfFile.read('masked.asdf') as f2:
+    with asdf.AsdfFile.open('masked.asdf') as f2:
         assert len(list(f2.blocks.internal_blocks)) == 0
         assert_array_equal(f.tree['test'], f2.tree['test'])
 

--- a/pyasdf/tags/core/tests/test_ndarray.py
+++ b/pyasdf/tags/core/tests/test_ndarray.py
@@ -381,11 +381,10 @@ def test_masked_array_stay_open_bug(tmpdir):
     }
 
     f = asdf.AsdfFile(tree)
-    with f.write_to(tmppath):
-        pass
+    f.write_to(tmppath)
 
     for i in range(1000):
-        with asdf.AsdfFile.read(tmppath) as f2:
+        with asdf.AsdfFile.open(tmppath) as f2:
             np.sum(f2.tree['test'])
 
     # fails with "too many open files" if the masked arrays

--- a/pyasdf/tags/unit/tests/test_unit.py
+++ b/pyasdf/tags/unit/tests/test_unit.py
@@ -18,6 +18,5 @@ unit: !unit/unit "2.1798721  10-18kg m2 s-2"
     """
 
     buff = helpers.yaml_to_asdf(yaml)
-    ff = asdf.AsdfFile.read(buff)
-
-    assert ff.tree['unit'].is_equivalent(u.Ry)
+    with asdf.AsdfFile.open(buff) as ff:
+        assert ff.tree['unit'].is_equivalent(u.Ry)

--- a/pyasdf/tests/helpers.py
+++ b/pyasdf/tests/helpers.py
@@ -86,15 +86,16 @@ def assert_roundtrip_tree(
     AsdfFile(tree).write_to(buff, **write_options)
     assert not buff.closed
     buff.seek(0)
-    ff = AsdfFile.read(buff, mode='rw')
-    assert not buff.closed
-    assert isinstance(ff.tree, AsdfObject)
-    assert_tree_match(tree, ff.tree)
-    if asdf_check_func:
-        asdf_check_func(ff)
+    with AsdfFile.open(buff, mode='rw') as ff:
+        assert not buff.closed
+        assert isinstance(ff.tree, AsdfObject)
+        assert_tree_match(tree, ff.tree)
+        if asdf_check_func:
+            asdf_check_func(ff)
 
     buff.seek(0)
-    content = AsdfFile.read(buff, _get_yaml_content=True)
+    content = AsdfFile.open(buff, _get_yaml_content=True)
+    buff.close()
     # We *never* want to get any raw python objects out
     assert b'!!python' not in content
     assert b'!core/asdf' in content
@@ -103,9 +104,9 @@ def assert_roundtrip_tree(
         raw_yaml_check_func(content)
 
     # Then, test writing/reading to a real file
-    with AsdfFile(tree) as ff:
-        ff.write_to(fname, **write_options)
-    with AsdfFile.read(fname, mode='rw') as ff:
+    ff = AsdfFile(tree)
+    ff.write_to(fname, **write_options)
+    with AsdfFile.open(fname, mode='rw') as ff:
         assert_tree_match(tree, ff.tree)
         if asdf_check_func:
             asdf_check_func(ff)

--- a/pyasdf/tests/test_asdftypes.py
+++ b/pyasdf/tests/test_asdftypes.py
@@ -67,17 +67,18 @@ b: !core/complex
     """
 
     buff = helpers.yaml_to_asdf(yaml)
-    ff = asdf.AsdfFile.read(
-        buff, extensions=FractionExtension())
-    assert ff.tree['a'] == fractions.Fraction(2, 3)
+    with asdf.AsdfFile.open(
+        buff, extensions=FractionExtension()) as ff:
+        assert ff.tree['a'] == fractions.Fraction(2, 3)
 
-    buff = io.BytesIO()
-    ff.write_to(buff)
+        buff = io.BytesIO()
+        ff.write_to(buff)
 
     buff = helpers.yaml_to_asdf(yaml)
-    ff = asdf.AsdfFile.read(
-        buff, extensions=FractionCallable())
-    assert ff.tree['a'] == fractions.Fraction(2, 3)
+    with asdf.AsdfFile.open(
+            buff, extensions=FractionCallable()) as ff:
+        assert ff.tree['a'] == fractions.Fraction(2, 3)
 
     buff = io.BytesIO()
     ff.write_to(buff)
+    buff.close()

--- a/pyasdf/tests/test_compression.py
+++ b/pyasdf/tests/test_compression.py
@@ -38,34 +38,36 @@ def _roundtrip(tmpdir, tree, compression=None,
                write_options={}, read_options={}):
     tmpfile = os.path.join(str(tmpdir), 'test.asdf')
 
-    with asdf.AsdfFile(tree) as ff:
-        ff.set_array_compression(tree['science_data'], compression)
-        ff.write_to(tmpfile, **write_options)
+    ff = asdf.AsdfFile(tree)
+    ff.set_array_compression(tree['science_data'], compression)
+    ff.write_to(tmpfile, **write_options)
+
+    with asdf.AsdfFile.open(tmpfile, mode="rw") as ff:
         ff.update(**write_options)
 
-    with asdf.AsdfFile().read(tmpfile, **read_options) as ff:
+    with asdf.AsdfFile.open(tmpfile, **read_options) as ff:
         helpers.assert_tree_match(tree, ff.tree)
 
     # Also test saving to a buffer
     buff = io.BytesIO()
 
-    with asdf.AsdfFile(tree) as ff:
-        ff.set_array_compression(tree['science_data'], compression)
-        ff.write_to(buff, **write_options)
+    ff = asdf.AsdfFile(tree)
+    ff.set_array_compression(tree['science_data'], compression)
+    ff.write_to(buff, **write_options)
 
     buff.seek(0)
-    with asdf.AsdfFile().read(buff, **read_options) as ff:
+    with asdf.AsdfFile.open(buff, **read_options) as ff:
         helpers.assert_tree_match(tree, ff.tree)
 
     # Test saving to a non-seekable buffer
     buff = io.BytesIO()
 
-    with asdf.AsdfFile(tree) as ff:
-        ff.set_array_compression(tree['science_data'], compression)
-        ff.write_to(generic_io.OutputStream(buff), **write_options)
+    ff = asdf.AsdfFile(tree)
+    ff.set_array_compression(tree['science_data'], compression)
+    ff.write_to(generic_io.OutputStream(buff), **write_options)
 
     buff.seek(0)
-    with asdf.AsdfFile().read(generic_io.InputStream(buff), **read_options) as ff:
+    with asdf.AsdfFile.open(generic_io.InputStream(buff), **read_options) as ff:
         helpers.assert_tree_match(tree, ff.tree)
 
     return ff

--- a/pyasdf/tests/test_yaml.py
+++ b/pyasdf/tests/test_yaml.py
@@ -134,7 +134,7 @@ unit: !<tag:stsci.edu:asdf/0.1.0/unit/unit> m
     # Check that fully-qualified explicit tags work
 
     buff = helpers.yaml_to_asdf(yaml, yaml_headers=False)
-    ff = asdf.AsdfFile.read(buff)
+    ff = asdf.AsdfFile.open(buff)
 
     assert isinstance(ff.tree['unit'], u.UnitBase)
 
@@ -171,10 +171,10 @@ def test_yaml_nan_inf():
         }
 
     buff = io.BytesIO()
-    ff = asdf.AsdfFile(tree).write_to(buff)
+    ff = asdf.AsdfFile(tree)
+    ff.write_to(buff)
     buff.seek(0)
-    ff = asdf.AsdfFile().read(buff)
-
-    assert np.isnan(ff.tree['a'])
-    assert np.isinf(ff.tree['b'])
-    assert np.isinf(ff.tree['c'])
+    with asdf.AsdfFile.open(buff) as ff:
+        assert np.isnan(ff.tree['a'])
+        assert np.isinf(ff.tree['b'])
+        assert np.isinf(ff.tree['c'])


### PR DESCRIPTION
This is an alternative to #116.  Fix #107, fix #109.

This is an attempt to fix up context manager usage at the expense of:

- the streaming API which is now a little less convenient (since it relies on having a raw file handle).  But that's advanced usage anyway

- It's no longer possible to `write_to` and then `update` -- one must `open` and then `update`. 

@astrofrog: Your thoughts?