### PR TITLE
Remove merge conflict in docs/index.rst

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -78,13 +78,4 @@ See also
 Reference/API
 -------------
 
-<<<<<<< HEAD
 .. automodapi:: pyasdf
-=======
-.. note:: The layout of this directory is simply a suggestion.  To follow
-          traditional practice, do *not* edit this page, but instead place
-          all documentation for the affiliated package inside ``packagename/``.
-          The traditional practice was intended to allow the affiliated
-          package to eventually be merged into the main astropy package.
-          You can follow this practice or choose your own layout.
->>>>>>> template/master


### PR DESCRIPTION
This fixes some warnings when building the docs.