### PR TITLE
Fix endian problems in FITS-in-ASDF when creating FITS file based on tree

### DIFF
--- a/pyasdf/block.py
+++ b/pyasdf/block.py
@@ -508,6 +508,9 @@ class Block(object):
     def size(self):
         return self._size + self.header_size
 
+    def override_byteorder(self, byteorder):
+        return byteorder
+
     @property
     def array_storage(self):
         return self._array_storage

--- a/pyasdf/fits_embed.py
+++ b/pyasdf/fits_embed.py
@@ -42,6 +42,9 @@ class _FitsBlock(object):
     def array_storage(self):
         return 'fits'
 
+    def override_byteorder(self, byteorder):
+        return 'big'
+
 
 class _EmbeddedBlockManager(block.BlockManager):
     def __init__(self, hdulist, asdffile):
@@ -140,13 +143,13 @@ class AsdfInFits(asdf.AsdfFile):
 
     def write_to(self, filename, all_array_storage=None,
                  all_array_compression=None, auto_inline=None,
-                 pad_blocks=False):
+                 pad_blocks=False, *args, **kwargs):
         self._update_asdf_extension(
             all_array_storage=all_array_storage,
             all_array_compression=all_array_compression,
             auto_inline=auto_inline, pad_blocks=pad_blocks)
 
-        self._hdulist.writeto(filename)
+        self._hdulist.writeto(filename, *args, **kwargs)
 
     def update(self, all_array_storage=None, all_array_compression=None,
                auto_inline=None, pad_blocks=False):

--- a/pyasdf/fits_embed.py
+++ b/pyasdf/fits_embed.py
@@ -106,6 +106,28 @@ class AsdfInFits(asdf.AsdfFile):
         self._blocks = _EmbeddedBlockManager(hdulist, self)
         self._hdulist = hdulist
 
+    def __exit__(self, typ, value, traceback):
+        for hdu in self._hdulist:
+            if hdu.data is not None:
+                base = util.get_array_base(hdu.data)
+                if hasattr(base, 'flush'):
+                    base.flush()
+                    base._mmap.close()
+        self._hdulist.close()
+
+        asdf.AsdfFile.__exit__(self, type, value, traceback)
+
+    def close(self):
+        for hdu in self._hdulist:
+            if hdu.data is not None:
+                base = util.get_array_base(hdu.data)
+                if hasattr(base, 'flush'):
+                    base.flush()
+                    base._mmap.close()
+        self._hdulist.close()
+
+        asdf.AsdfFile.close(self)
+
     @classmethod
     def open(cls, hdulist, uri=None, validate_checksums=False, extensions=None):
         try:

--- a/pyasdf/tags/core/ndarray.py
+++ b/pyasdf/tags/core/ndarray.py
@@ -397,6 +397,8 @@ class NDArrayType(AsdfType):
         dtype, byteorder = numpy_dtype_to_asdf_datatype(
             dtype, include_byteorder=(block.array_storage != 'inline'))
 
+        byteorder = block.override_byteorder(byteorder)
+
         if block.array_storage == 'inline':
             listdata = numpy_array_to_list(data)
             result['data'] = yamlutil.custom_tree_to_tagged_tree(


### PR DESCRIPTION
Needs a little hack to make sure the endianness of FITS extensions is always "big".

[This is part of the ongoing work to support ASDF in jwst_lib.models]