### PR TITLE
Remove none keys on modify

### DIFF
--- a/pyasdf/tests/test_low_level.py
+++ b/pyasdf/tests/test_low_level.py
@@ -15,6 +15,7 @@ from numpy.testing import assert_array_equal
 from .. import asdf
 from .. import constants
 from .. import generic_io
+from .. import treeutil
 
 from . import helpers
 
@@ -752,3 +753,20 @@ def test_atomic_write(tmpdir):
 
     with asdf.AsdfFile.open(tmpfile) as ff:
         ff.write_to(tmpfile)
+
+
+def test_walk_and_modify_remove_keys():
+    tree = {
+        'foo': 42,
+        'bar': 43
+    }
+
+    def func(x):
+        if x == 42:
+            return None
+        return x
+
+    tree2 = treeutil.walk_and_modify(tree, func)
+
+    assert 'foo' not in tree2
+    assert 'bar' in tree2

--- a/pyasdf/treeutil.py
+++ b/pyasdf/treeutil.py
@@ -81,7 +81,9 @@ def walk_and_modify(top, callback):
             new_seen = seen | set([id(tree)])
             result = tree.__class__()
             for key, val in six.iteritems(tree):
-                result[key] = recurse(val, new_seen)
+                val = recurse(val, new_seen)
+                if val is not None:
+                    result[key] = val
             if isinstance(tree, Tagged):
                 result = tag_object(tree.tag, result)
         elif isinstance(tree, (list, tuple)):


### PR DESCRIPTION
`walk_and_modify` shouldn't add a key/value pair if the functor returns `None`.

[This is part of the ongoing work to support ASDF in jwst_lib.models]