### PR TITLE
Pass a reader directly to PyYAML

### DIFF
--- a/pyasdf/generic_io.py
+++ b/pyasdf/generic_io.py
@@ -648,7 +648,7 @@ class RandomAccessFile(GenericFile):
     def seekable(self):
         return True
 
-    def _peek(self, size=None):
+    def _peek(self, size=-1):
         cursor = self.tell()
         content = self.read(size)
         self.seek(cursor, os.SEEK_SET)
@@ -744,8 +744,8 @@ class InputStream(GenericFile):
         self._fd = fd
         self._buffer = b''
 
-    def _peek(self, size=None):
-        if size is None:
+    def _peek(self, size=-1):
+        if size < 0:
             self._buffer += self._fd.read()
         else:
             len_buffer = len(self._buffer)

--- a/pyasdf/generic_io.py
+++ b/pyasdf/generic_io.py
@@ -199,7 +199,13 @@ class _TruncatedReader(object):
 
     def read(self, nbytes=None):
         if self._past_end:
-            return b''
+            if six.PY3:
+                # This a workaround for what is probably a bug in
+                # PyYAML: It expects the end marker to be a unicode
+                # string even though the file is open in binary mode.
+                return ''
+            else:
+                return b''
 
         if nbytes is None:
             content = self._fd._peek()

--- a/pyasdf/generic_io.py
+++ b/pyasdf/generic_io.py
@@ -29,10 +29,6 @@ import numpy as np
 
 from .extern import atomicfile
 
-import yaml
-
-_CYAML_ON_PY3 = six.PY3 and getattr(yaml, '__with_libyaml__', False)
-
 
 __all__ = ['get_file', 'resolve_uri', 'relative_uri']
 
@@ -203,13 +199,7 @@ class _TruncatedReader(object):
 
     def read(self, nbytes=None):
         if self._past_end:
-            if _CYAML_ON_PY3:
-                # This a workaround for what is probably a bug in
-                # PyYAML: It expects the end marker to be a unicode
-                # string even though the file is open in binary mode.
-                return ''
-            else:
-                return b''
+            return b''
 
         if nbytes is None:
             content = self._fd._peek()
@@ -580,7 +570,7 @@ class GenericFile(object):
                 content = reader.read(self.block_size)
             except ValueError:
                 return False
-            if content == '':
+            if content == b'':
                 return True
 
     def fast_forward(self, size):

--- a/pyasdf/generic_io.py
+++ b/pyasdf/generic_io.py
@@ -29,6 +29,10 @@ import numpy as np
 
 from .extern import atomicfile
 
+import yaml
+
+_CYAML_ON_PY3 = six.PY3 and getattr(yaml, '__with_libyaml__', False)
+
 
 __all__ = ['get_file', 'resolve_uri', 'relative_uri']
 
@@ -199,7 +203,7 @@ class _TruncatedReader(object):
 
     def read(self, nbytes=None):
         if self._past_end:
-            if six.PY3:
+            if _CYAML_ON_PY3:
                 # This a workaround for what is probably a bug in
                 # PyYAML: It expects the end marker to be a unicode
                 # string even though the file is open in binary mode.

--- a/pyasdf/yamlutil.py
+++ b/pyasdf/yamlutil.py
@@ -11,7 +11,6 @@ import numpy as np
 import yaml
 
 from . constants import YAML_TAG_PREFIX
-from . import reference
 from . import schema
 from . import tagged
 from . import treeutil

--- a/pyasdf/yamlutil.py
+++ b/pyasdf/yamlutil.py
@@ -246,29 +246,16 @@ def tagged_tree_to_custom_tree(tree, ctx):
     return treeutil.walk_and_modify(tree, walker)
 
 
-def load_tree(yaml_content, ctx, do_not_fill_defaults=False):
+def load_tree(stream):
     """
-    Load YAML, returning a tree of objects and custom types.
+    Load YAML, returning a tree of objects.
 
     Parameters
     ----------
-    yaml_content : bytes
-        The raw serialized YAML content.
-
-    ctx : Context
-        The parsing context.
+    stream : readable file-like object
+        Stream containing the raw YAML content.
     """
-    class AsdfLoaderTmp(AsdfLoader):
-        pass
-    AsdfLoaderTmp.ctx = ctx
-
-    tree = yaml.load(yaml_content, Loader=AsdfLoaderTmp)
-    tree = reference.find_references(tree, ctx)
-    if not do_not_fill_defaults:
-        schema.fill_defaults(tree, ctx)
-    schema.validate(tree, ctx)
-    tree = tagged_tree_to_custom_tree(tree, ctx)
-    return tree
+    return yaml.load(stream, Loader=AsdfLoader)
 
 
 def dump_tree(tree, fd, ctx):


### PR DESCRIPTION
No longer need to read the entire YAML content into memory just to parse it.