### PR TITLE
Add support for time type

### DIFF
--- a/docs/pyasdf/extensions.rst
+++ b/docs/pyasdf/extensions.rst
@@ -39,11 +39,9 @@ Then, the Python implementation.  See the `pyasdf.AsdfType` and
     import os
 
     import pyasdf
+    from pyasdf import util
 
     import fractions
-
-    from six.moves.urllib.parse import urljoin
-    from six.moves.urllib.request import pathname2url
 
     class FractionType(pyasdf.AsdfType):
         name = 'fraction'
@@ -73,9 +71,8 @@ Then, the Python implementation.  See the `pyasdf.AsdfType` and
         @property
         def url_mapping(self):
             return [('http://nowhere.org/schemas/custom/1.0.0/',
-                     urljoin('file:', pathname2url(os.path.join(
-                         os.path.dirname(__file__))) +
-                         '/{url_suffix}.yaml')]
+                     util.filepath_to_url(os.path.dirname(__file__))
+                     + '/{url_suffix}.yaml')]
 
 Adding custom validators
 ------------------------

--- a/pyasdf/asdf.py
+++ b/pyasdf/asdf.py
@@ -60,19 +60,19 @@ class AsdfFile(versioning.VersionedMixin):
         self._fd = None
         self._external_asdf_by_uri = {}
         self._blocks = block.BlockManager(self)
+        self._uri = None
         if tree is None:
             self.tree = {}
-            self._uri = uri
         elif isinstance(tree, AsdfFile):
             self._uri = tree.uri
             self._tree = tree.tree
             self.run_modifying_hook('copy_to_new_asdf')
             self.find_references()
-            self._uri = uri
         else:
             self.tree = tree
-            self._uri = uri
             self.find_references()
+        if uri is not None:
+            self._uri = uri
 
     def __enter__(self):
         return self
@@ -706,7 +706,7 @@ class AsdfFile(versioning.VersionedMixin):
             with this name, it will be called for every instance of the
             corresponding custom type in the tree.
         """
-        def walker(node):
+        def walker(node, json_id):
             tag = self.type_index.from_custom_type(type(node))
             if tag is not None:
                 hook = getattr(tag, hookname, None)

--- a/pyasdf/extension.py
+++ b/pyasdf/extension.py
@@ -93,11 +93,10 @@ class AsdfExtension(object):
         alongside as data alongside Python module::
 
             return [('http://nowhere.org/schemas/custom/1.0.0/',
-                    urljoin('file:',
-                      pathname2url(
-                        os.path.join(
-                          SCHEMA_PATH, 'stsci.edu')))
-                    + '/{url_suffix}.yaml')]
+                    pyasdf.util.filepath_to_url(
+                        os.path.join(SCHEMA_PATH, 'stsci.edu')) +
+                    '/{url_suffix}.yaml'
+                   )]
         """
         pass
 

--- a/pyasdf/generic_io.py
+++ b/pyasdf/generic_io.py
@@ -145,14 +145,13 @@ def resolve_uri(base, uri):
     Resolve a URI against a base URI.
     """
     if base is None:
-        if uri == '':
-            return ''
-        parsed = urlparse.urlparse(uri)
-        if parsed.path.startswith('/'):
-            return uri
+        base = ''
+    resolved = urlparse.urljoin(base, uri)
+    parsed = urlparse.urlparse(resolved)
+    if parsed.path != '' and not parsed.path.startswith('/'):
         raise ValueError(
-            "Can not resolve relative URLs since the base is unknown.")
-    return urlparse.urljoin(base, uri)
+            "Resolved to relative URL")
+    return resolved
 
 
 def relative_uri(source, target):

--- a/pyasdf/generic_io.py
+++ b/pyasdf/generic_io.py
@@ -22,12 +22,14 @@ import sys
 from astropy.extern import six
 from astropy.extern.six.moves import xrange
 from astropy.extern.six.moves.urllib import parse as urlparse
-from astropy.extern.six.moves.urllib.request import url2pathname, pathname2url
+from astropy.extern.six.moves.urllib.request import url2pathname
 from astropy.utils.misc import InheritDocstrings
 
 import numpy as np
 
 from .extern import atomicfile
+
+from . import util
 
 
 __all__ = ['get_file', 'resolve_uri', 'relative_uri']
@@ -171,7 +173,10 @@ def relative_uri(source, target):
         return target
 
     if relative is None:
-        relative = os.path.relpath(tu[2], os.path.dirname(su[2]))
+        if tu[2] == su[2]:
+            relative = ''
+        else:
+            relative = os.path.relpath(tu[2], os.path.dirname(su[2]))
     if relative == '.':
         relative = ''
     relative = urlparse.urlunparse(["", "", relative] + extra)
@@ -684,8 +689,7 @@ class RealFile(RandomAccessFile):
         self._size = stat.st_size
         if (uri is None and
             isinstance(fd.name, six.string_types)):
-            self._uri = urlparse.urljoin(
-                'file:', pathname2url(os.path.abspath(fd.name)))
+            self._uri = util.filepath_to_url(os.path.abspath(fd.name))
 
     def write_array(self, arr):
         if isinstance(arr, np.memmap) and getattr(arr, 'fd', None) is self:

--- a/pyasdf/resolver.py
+++ b/pyasdf/resolver.py
@@ -7,10 +7,9 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 import os.path
 
 from astropy.extern import six
-from astropy.extern.six.moves.urllib.parse import urljoin
-from astropy.extern.six.moves.urllib.request import pathname2url
 
 from . import constants
+from . import util
 
 
 SCHEMA_PATH = os.path.abspath(
@@ -96,9 +95,9 @@ class Resolver(object):
 
 DEFAULT_URL_MAPPING = [
     (constants.STSCI_SCHEMA_URI_BASE,
-     urljoin('file:', pathname2url(os.path.join(
-         SCHEMA_PATH, 'stsci.edu'))) + '/{url_suffix}.yaml')
-]
+     util.filepath_to_url(
+         os.path.join(SCHEMA_PATH, 'stsci.edu')) +
+         '/{url_suffix}.yaml')]
 
 
 default_url_mapping = Resolver(DEFAULT_URL_MAPPING, 'url')

--- a/pyasdf/schema.py
+++ b/pyasdf/schema.py
@@ -20,7 +20,6 @@ from . import constants
 from . import generic_io
 from . import reference
 from . import resolver as mresolver
-from . import tagged
 from . import treeutil
 from . import util
 

--- a/pyasdf/schema.py
+++ b/pyasdf/schema.py
@@ -338,7 +338,7 @@ def load_schema(url, resolver=None, resolve_references=False):
             if json_id is None:
                 json_id = url
             if isinstance(node, dict) and '$ref' in node:
-                suburl = generic_io.resolve_uri(url, node['$ref'])
+                suburl = generic_io.resolve_uri(json_id, node['$ref'])
                 parts = urlparse.urlparse(suburl)
                 fragment = parts.fragment
                 if len(fragment):

--- a/pyasdf/tags/__init__.py
+++ b/pyasdf/tags/__init__.py
@@ -7,5 +7,6 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 from . import core
 from . import fits
 from . import unit
+from . import time
 from . import transform
 from . import wcs

--- a/pyasdf/tags/core/ndarray.py
+++ b/pyasdf/tags/core/ndarray.py
@@ -185,8 +185,6 @@ def inline_data_asarray(inline, dtype=None):
 
 
 def numpy_array_to_list(array):
-    # Convert byte string arrays to unicode string arrays, since YAML
-    # doesn't handle the former.  This just assumes they are Latin-1.
     def tolist(x):
         if isinstance(x, (np.ndarray, NDArrayType)):
             if x.dtype.char == 'S':
@@ -199,7 +197,17 @@ def numpy_array_to_list(array):
         else:
             return x
 
-    return tolist(array)
+    def ascii_to_unicode(x):
+        # Convert byte string arrays to unicode string arrays, since YAML
+        # doesn't handle the former.
+        if isinstance(x, list):
+            return [ascii_to_unicode(y) for y in x]
+        elif isinstance(x, bytes):
+            return x.decode('ascii')
+        else:
+            return x
+
+    return ascii_to_unicode(tolist(array))
 
 
 class NDArrayType(AsdfType):

--- a/pyasdf/tags/core/tests/test_ndarray.py
+++ b/pyasdf/tags/core/tests/test_ndarray.py
@@ -8,8 +8,6 @@ import os
 import sys
 
 from astropy.extern import six
-from astropy.extern.six.moves.urllib.parse import urljoin
-from astropy.extern.six.moves.urllib.request import pathname2url
 from astropy.tests.helper import pytest
 
 import numpy as np
@@ -22,6 +20,7 @@ import yaml
 
 from ....tests import helpers
 from .... import asdf
+from .... import util
 
 from .. import ndarray
 
@@ -41,10 +40,9 @@ class CustomExtension:
 
     @property
     def url_mapping(self):
-        return [('http://nowhere.org/schemas/custom/1.0.0/',
-                 urljoin('file:', pathname2url(os.path.join(
-                     TEST_DATA_PATH))) + '/{url_suffix}.yaml')]
-
+        return [(
+            'http://nowhere.org/schemas/custom/1.0.0/',
+            util.filepath_to_url(TEST_DATA_PATH) + '/{url_suffix}.yaml')]
 
 
 def test_sharing(tmpdir):

--- a/pyasdf/tags/time/__init__.py
+++ b/pyasdf/tags/time/__init__.py
@@ -1,0 +1,6 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, unicode_literals, print_function
+
+from .time import TimeType

--- a/pyasdf/tags/time/tests/test_time.py
+++ b/pyasdf/tags/time/tests/test_time.py
@@ -1,0 +1,36 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, unicode_literals, print_function
+
+from astropy.extern import six
+from astropy import time
+
+import numpy as np
+
+from .... import asdf
+from .... import yamlutil
+from ....tests import helpers
+
+
+def test_time(tmpdir):
+    time_array = time.Time(
+        np.arange(100), format="unix")
+
+    tree = {
+        'large_time_array': time_array
+    }
+
+    helpers.assert_roundtrip_tree(tree, tmpdir)
+
+
+def test_isot(tmpdir):
+    tree = {
+        'time': time.Time('2000-01-01T00:00:00.000')
+    }
+
+    helpers.assert_roundtrip_tree(tree, tmpdir)
+
+    ff = asdf.AsdfFile(tree)
+    tree = yamlutil.custom_tree_to_tagged_tree(ff.tree, ff)
+    assert isinstance(tree['time'], six.text_type)

--- a/pyasdf/tags/time/time.py
+++ b/pyasdf/tags/time/time.py
@@ -3,6 +3,7 @@
 
 from __future__ import absolute_import, division, unicode_literals, print_function
 
+import datetime
 
 import numpy as np
 
@@ -27,10 +28,13 @@ _astropy_format_to_asdf_format = {
 
 class TimeType(AsdfType):
     name = 'time/time'
-    types = [time.core.Time]
+    types = [time.core.Time, datetime.datetime]
 
     @classmethod
     def to_tree(cls, node, ctx):
+        if isinstance(node, datetime.datetime):
+            node = time.Time(node)
+
         format = node.format
 
         if format == 'byear':

--- a/pyasdf/tags/time/time.py
+++ b/pyasdf/tags/time/time.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from astropy.extern import six
 from astropy import time
+from astropy import units as u
 
 from ...asdftypes import AsdfType
 from ... import yamlutil
@@ -85,12 +86,15 @@ class TimeType(AsdfType):
         scale = node.get('scale')
         location = node.get('location')
         if location is not None:
+            unit = location.get('unit', u.m)
             if 'x' in location:
-                location = (location['x'], location['y'], location['z'])
+                location = (location['x'] * unit,
+                            location['y'] * unit,
+                            location['z'] * unit)
             else:
                 location = ('{0}d'.format(location['longitude']),
                             '{0}d'.format(location['latitude']),
-                            location.get('height', 0.0))
+                            location.get('height', 0.0) * unit)
 
         return time.Time(value, format=format, scale=scale, location=location)
 

--- a/pyasdf/tags/time/time.py
+++ b/pyasdf/tags/time/time.py
@@ -1,0 +1,105 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, unicode_literals, print_function
+
+
+import numpy as np
+
+from astropy.extern import six
+from astropy import time
+
+from ...asdftypes import AsdfType
+from ... import yamlutil
+
+
+_guessable_formats = set(['iso', 'byear', 'jyear', 'yday'])
+
+
+_astropy_format_to_asdf_format = {
+    'isot': 'iso',
+    'byear_str': 'byear',
+    'jyear_str': 'jyear'
+}
+
+
+
+class TimeType(AsdfType):
+    name = 'time/time'
+    types = [time.core.Time]
+
+    @classmethod
+    def to_tree(cls, node, ctx):
+        format = node.format
+
+        if format == 'byear':
+            node = time.Time(node, format='byear_str')
+
+        elif format == 'jyear':
+            node = time.Time(node, format='jyear_str')
+
+        elif format in ('fits', 'datetime', 'plot_date'):
+            node = time.Time(node, format='isot')
+
+        format = node.format
+
+        format = _astropy_format_to_asdf_format.get(format, format)
+
+        guessable_format = format in _guessable_formats
+
+        if node.scale == 'utc' and guessable_format:
+            if node.isscalar:
+                return node.value
+            else:
+                return yamlutil.custom_tree_to_tagged_tree(
+                    node.value, ctx)
+
+        d = {'value': yamlutil.custom_tree_to_tagged_tree(node.value, ctx)}
+
+        if not guessable_format:
+            d['format'] = format
+
+        if node.scale != 'utc':
+            d['scale'] = scale
+
+        if node.location is not None:
+            d['location'] = {
+                'x': node.location.x,
+                'y': node.location.y,
+                'z': node.location.z
+            }
+
+        return d
+
+    @classmethod
+    def from_tree(cls, node, ctx):
+        if isinstance(node, (six.string_types, list, np.ndarray)):
+            t = time.Time(node)
+            format = _astropy_format_to_asdf_format.get(t.format, t.format)
+            if format not in _guessable_formats:
+                raise ValueError("Invalid time '{0}'".format(node))
+            return t
+
+        value = node['value']
+        format = node.get('format')
+        scale = node.get('scale')
+        location = node.get('location')
+        if location is not None:
+            if 'x' in location:
+                location = (location['x'], location['y'], location['z'])
+            else:
+                location = ('{0}d'.format(location['longitude']),
+                            '{0}d'.format(location['latitude']),
+                            location.get('height', 0.0))
+
+        return time.Time(value, format=format, scale=scale, location=location)
+
+    @classmethod
+    def assert_equal(cls, old, new):
+        from numpy.testing import assert_array_equal
+
+        assert old.format == new.format
+        assert old.scale == new.scale
+        assert old.location == new.location
+
+        assert_array_equal(old, new)

--- a/pyasdf/tags/time/time.py
+++ b/pyasdf/tags/time/time.py
@@ -92,9 +92,9 @@ class TimeType(AsdfType):
                             location['y'] * unit,
                             location['z'] * unit)
             else:
-                location = ('{0}d'.format(location['longitude']),
-                            '{0}d'.format(location['latitude']),
-                            location.get('height', 0.0) * unit)
+                location = ('{0}d'.format(location['long']),
+                            '{0}d'.format(location['lat']),
+                            location.get('h', 0.0) * unit)
 
         return time.Time(value, format=format, scale=scale, location=location)
 

--- a/pyasdf/tags/time/time.py
+++ b/pyasdf/tags/time/time.py
@@ -61,7 +61,7 @@ class TimeType(AsdfType):
             d['format'] = format
 
         if node.scale != 'utc':
-            d['scale'] = scale
+            d['scale'] = node.scale
 
         if node.location is not None:
             d['location'] = {

--- a/pyasdf/tags/transform/basic.py
+++ b/pyasdf/tags/transform/basic.py
@@ -112,7 +112,7 @@ class ConstantType(TransformType):
     @classmethod
     def to_tree_transform(cls, data, ctx):
         return {
-            'value': data.amplitude
+            'value': data.amplitude.value
         }
 
 

--- a/pyasdf/tests/test_asdftypes.py
+++ b/pyasdf/tests/test_asdftypes.py
@@ -8,10 +8,9 @@ import os
 
 from .. import asdf
 from .. import asdftypes
-from . import helpers
+from .. import util
 
-from astropy.extern.six.moves.urllib.parse import urljoin
-from astropy.extern.six.moves.urllib.request import pathname2url
+from . import helpers
 
 TEST_DATA_PATH = os.path.join(os.path.dirname(__file__), 'data')
 
@@ -47,8 +46,8 @@ def test_custom_tag():
         @property
         def url_mapping(self):
             return [('http://nowhere.org/schemas/custom/1.0.0/',
-                     urljoin('file:', pathname2url(os.path.join(
-                         TEST_DATA_PATH))) + '/{url_suffix}.yaml')]
+                     util.filepath_to_url(TEST_DATA_PATH) +
+                     '/{url_suffix}.yaml')]
 
     class FractionCallable(FractionExtension):
         @property

--- a/pyasdf/tests/test_generic_io.py
+++ b/pyasdf/tests/test_generic_io.py
@@ -9,14 +9,13 @@ import sys
 
 from astropy.extern import six
 import astropy.extern.six.moves.urllib.request as urllib_request
-from astropy.extern.six.moves.urllib.parse import urljoin
-from astropy.extern.six.moves.urllib.request import pathname2url
 from astropy.tests.helper import pytest, remote_data
 
 import numpy as np
 
 from .. import asdf
 from .. import generic_io
+from .. import util
 
 from . import helpers
 
@@ -87,13 +86,13 @@ def test_path(tree, tmpdir):
     def get_write_fd():
         f = generic_io.get_file(path, mode='w')
         assert isinstance(f, generic_io.RealFile)
-        assert f._uri == urljoin('file:', pathname2url(path))
+        assert f._uri == util.filepath_to_url(path)
         return f
 
     def get_read_fd():
         f = generic_io.get_file(path, mode='r')
         assert isinstance(f, generic_io.RealFile)
-        assert f._uri == urljoin('file:', pathname2url(path))
+        assert f._uri == util.filepath_to_url(path)
         # This is to check for a "feature" in Python 3.x that reading zero
         # bytes from a socket causes it to stop.  We have code in generic_io.py
         # to workaround it.
@@ -112,14 +111,14 @@ def test_open2(tree, tmpdir):
     def get_write_fd():
         f = generic_io.get_file(open(path, 'wb'), mode='w')
         assert isinstance(f, generic_io.RealFile)
-        assert f._uri == urljoin('file:', pathname2url(path))
+        assert f._uri == util.filepath_to_url(path)
         f._close = True
         return f
 
     def get_read_fd():
         f = generic_io.get_file(open(path, 'rb'), mode='r')
         assert isinstance(f, generic_io.RealFile)
-        assert f._uri == urljoin('file:', pathname2url(path))
+        assert f._uri == util.filepath_to_url(path)
         f._close = True
         return f
 
@@ -175,14 +174,14 @@ def test_io_open(tree, tmpdir):
     def get_write_fd():
         f = generic_io.get_file(io.open(path, 'wb'), mode='w')
         assert isinstance(f, generic_io.RealFile)
-        assert f._uri == urljoin('file:', pathname2url(path))
+        assert f._uri == util.filepath_to_url(path)
         f._close = True
         return f
 
     def get_read_fd():
         f = generic_io.get_file(io.open(path, 'r+b'), mode='rw')
         assert isinstance(f, generic_io.RealFile)
-        assert f._uri == urljoin('file:', pathname2url(path))
+        assert f._uri == util.filepath_to_url(path)
         f._close = True
         return f
 

--- a/pyasdf/tests/test_low_level.py
+++ b/pyasdf/tests/test_low_level.py
@@ -761,7 +761,7 @@ def test_walk_and_modify_remove_keys():
         'bar': 43
     }
 
-    def func(x):
+    def func(x, json_id):
         if x == 42:
             return None
         return x

--- a/pyasdf/tests/test_reference.py
+++ b/pyasdf/tests/test_reference.py
@@ -108,7 +108,7 @@ def test_external_reference(tmpdir):
 
         assert_array_equal(ff.tree['internal'], exttree['cool_stuff']['a'])
 
-    with asdf.AsdfFile(tree, uri=pathname2url(
+    with asdf.AsdfFile(tree, uri='file:' + pathname2url(
             os.path.join(str(tmpdir), 'main.asdf'))) as ff:
         do_asserts(ff)
 

--- a/pyasdf/tests/test_reference.py
+++ b/pyasdf/tests/test_reference.py
@@ -10,12 +10,10 @@ import numpy as np
 from numpy.testing import assert_array_equal
 
 from astropy.tests.helper import pytest
-from astropy.extern.six.moves.urllib.request import pathname2url
-
-import yaml
 
 from .. import asdf
 from .. import reference
+from .. import util
 
 from ..tags.core import ndarray
 
@@ -108,7 +106,7 @@ def test_external_reference(tmpdir):
 
         assert_array_equal(ff.tree['internal'], exttree['cool_stuff']['a'])
 
-    with asdf.AsdfFile(tree, uri='file:' + pathname2url(
+    with asdf.AsdfFile(tree, uri=util.filepath_to_url(
             os.path.join(str(tmpdir), 'main.asdf'))) as ff:
         do_asserts(ff)
 
@@ -161,7 +159,7 @@ def test_external_reference_invalid(tmpdir):
     with pytest.raises(IOError):
         ff.resolve_references()
 
-    ff = asdf.AsdfFile(tree, uri=pathname2url(
+    ff = asdf.AsdfFile(tree, uri=util.filepath_to_url(
         os.path.join(str(tmpdir), 'main.asdf')))
     with pytest.raises(IOError):
         ff.resolve_references()
@@ -185,7 +183,7 @@ def test_external_reference_invalid_fragment(tmpdir):
             }
         }
 
-    with asdf.AsdfFile(tree, uri=pathname2url(
+    with asdf.AsdfFile(tree, uri=util.filepath_to_url(
             os.path.join(str(tmpdir), 'main.asdf'))) as ff:
         with pytest.raises(ValueError):
             ff.resolve_references()
@@ -196,7 +194,7 @@ def test_external_reference_invalid_fragment(tmpdir):
             }
         }
 
-    with asdf.AsdfFile(tree, uri=pathname2url(
+    with asdf.AsdfFile(tree, uri=util.filepath_to_url(
             os.path.join(str(tmpdir), 'main.asdf'))) as ff:
         with pytest.raises(ValueError):
             ff.resolve_references()
@@ -241,7 +239,8 @@ def test_internal_reference():
     tree = {
         'foo': 2
     }
-    ff = asdf.AsdfFile(tree, uri=pathname2url(os.path.abspath("test.asdf")))
+    ff = asdf.AsdfFile(
+        tree, uri=util.filepath_to_url(os.path.abspath("test.asdf")))
     ff.tree['bar'] = ff.make_reference([])
     buff = io.BytesIO()
     ff.write_to(buff)

--- a/pyasdf/tests/test_schema.py
+++ b/pyasdf/tests/test_schema.py
@@ -12,9 +12,6 @@ from astropy.extern import six
 from astropy.tests.helper import pytest
 from astropy import units as u
 
-from astropy.extern.six.moves.urllib.parse import urljoin
-from astropy.extern.six.moves.urllib.request import pathname2url
-
 from jsonschema import ValidationError
 
 import yaml
@@ -25,6 +22,7 @@ from .. import block
 from .. import resolver
 from .. import schema
 from .. import treeutil
+from .. import util
 
 from . import helpers
 
@@ -45,9 +43,8 @@ class CustomExtension:
     @property
     def url_mapping(self):
         return [('http://nowhere.org/schemas/custom/1.0.0/',
-                 urljoin('file:', pathname2url(os.path.join(
-                     TEST_DATA_PATH))) + '/{url_suffix}.yaml')]
-
+                 util.filepath_to_url(TEST_DATA_PATH) +
+                 '/{url_suffix}.yaml')]
 
 
 def test_violate_toplevel_schema():
@@ -108,12 +105,12 @@ def test_all_schema_examples():
     def test_example(args):
         fname, example = args
         buff = helpers.yaml_to_asdf('example: ' + example.strip())
-        ff = asdf.AsdfFile(uri=pathname2url(os.path.abspath(fname)))
+        ff = asdf.AsdfFile(uri=util.filepath_to_url(os.path.abspath(fname)))
 
         # Fake an external file
         ff2 = asdf.AsdfFile({'data': np.empty((1024*1024*8), dtype=np.uint8)})
         ff._external_asdf_by_uri[
-            pathname2url(
+            util.filepath_to_url(
                 os.path.abspath(
                     os.path.join(os.path.dirname(fname), 'external.asdf')))] = ff2
 

--- a/pyasdf/tests/test_schema.py
+++ b/pyasdf/tests/test_schema.py
@@ -128,7 +128,7 @@ def test_all_schema_examples():
         # Just test we can write it out.  A roundtrip test
         # wouldn't always yield the correct result, so those have
         # to be covered by "real" unit tests.
-        if 'external.asdf' not in buff.getvalue():
+        if b'external.asdf' not in buff.getvalue():
             buff = io.BytesIO()
             ff.write_to(buff)
 

--- a/pyasdf/util.py
+++ b/pyasdf/util.py
@@ -9,6 +9,8 @@ import math
 import struct
 
 from astropy.extern import six
+from astropy.extern.six.moves.urllib.parse import urljoin
+from astropy.extern.six.moves.urllib.request import pathname2url
 from astropy.extern.six.moves.urllib import parse as urlparse
 from astropy.extern.six.moves import zip as izip
 
@@ -60,6 +62,13 @@ def get_base_uri(uri):
     """
     parts = urlparse.urlparse(uri)
     return urlparse.urlunparse(list(parts[:5]) + [''])
+
+
+def filepath_to_url(path):
+    """
+    For a given local file path, return a file:// url.
+    """
+    return urljoin('file:', pathname2url(path))
 
 
 def nth_item(iterable, n, default=None):

--- a/pyasdf/yamlutil.py
+++ b/pyasdf/yamlutil.py
@@ -220,7 +220,7 @@ def custom_tree_to_tagged_tree(tree, ctx):
     directly representable in YAML, to a tree of basic data types,
     annotated with tags.
     """
-    def walker(node):
+    def walker(node, json_id):
         tag = ctx.type_index.from_custom_type(type(node))
         if tag is not None:
             return tag.to_tree_tagged(node, ctx)
@@ -234,7 +234,7 @@ def tagged_tree_to_custom_tree(tree, ctx):
     Convert a tree containing only basic data types, annotated with
     tags, to a tree containing custom data types.
     """
-    def walker(node):
+    def walker(node, json_id):
         tag_name = getattr(node, '_tag', None)
         if tag_name is not None:
             tag_type = ctx.type_index.from_yaml_tag(tag_name)


### PR DESCRIPTION
This is the implementation of spacetelescope/asdf-standard#87.

Adds a time type that can represent various kinds of time formats and scales.