### PR TITLE
Fix FITS file close handling

### DIFF
--- a/pyasdf/fits_embed.py
+++ b/pyasdf/fits_embed.py
@@ -106,36 +106,14 @@ class AsdfInFits(asdf.AsdfFile):
         self._blocks = _EmbeddedBlockManager(hdulist, self)
         self._hdulist = hdulist
 
-    def __exit__(self, typ, value, traceback):
-        for hdu in self._hdulist:
-            if hdu.data is not None:
-                base = util.get_array_base(hdu.data)
-                if hasattr(base, 'flush'):
-                    base.flush()
-                    base._mmap.close()
-        self._hdulist.close()
-
-        asdf.AsdfFile.__exit__(self, type, value, traceback)
-
-    def close(self):
-        for hdu in self._hdulist:
-            if hdu.data is not None:
-                base = util.get_array_base(hdu.data)
-                if hasattr(base, 'flush'):
-                    base.flush()
-                    base._mmap.close()
-        self._hdulist.close()
-
-        asdf.AsdfFile.close(self)
-
     @classmethod
     def open(cls, hdulist, uri=None, validate_checksums=False, extensions=None):
+        self = cls(hdulist, uri=uri, extensions=extensions)
+
         try:
             asdf_extension = hdulist[ASDF_EXTENSION_NAME]
         except (KeyError, IndexError, AttributeError):
-            return cls(hdulist, uri=uri, extensions=extensions)
-
-        self = cls(hdulist, extensions=extensions)
+            return self
 
         buff = io.BytesIO(asdf_extension.data)
 

--- a/pyasdf/tests/helpers.py
+++ b/pyasdf/tests/helpers.py
@@ -10,6 +10,7 @@ from astropy.extern import six
 
 from ..asdf import AsdfFile
 from ..asdftypes import _all_asdftypes
+from .. import util
 
 from ..tags.core import AsdfObject
 
@@ -169,3 +170,15 @@ def get_file_sizes(dirname):
         if os.path.isfile(path):
             files[filename] = os.stat(path).st_size
     return files
+
+
+def close_fits(hdulist):
+    """
+    Forcibly close all of the mmap'd HDUs in a FITS file.
+    """
+    for hdu in hdulist:
+        if hdu.data is not None:
+            base = util.get_array_base(hdu.data)
+            if hasattr(base, 'flush'):
+                base.flush()
+                base._mmap.close()

--- a/pyasdf/tests/test_fits_embed.py
+++ b/pyasdf/tests/test_fits_embed.py
@@ -13,7 +13,7 @@ from astropy.io import fits
 from .. import asdf
 from .. import fits_embed
 
-from .helpers import assert_tree_match
+from .helpers import assert_tree_match, close_fits
 
 
 def test_embed_asdf_in_fits_file(tmpdir):
@@ -54,6 +54,8 @@ def test_embed_asdf_in_fits_file(tmpdir):
 
             with asdf.AsdfFile.open('test.asdf') as ff:
                 assert_tree_match(tree, ff.tree)
+
+        close_fits(hdulist2)
 
 
 def test_embed_asdf_in_fits_file_anonymous_extensions(tmpdir):
@@ -99,6 +101,8 @@ def test_embed_asdf_in_fits_file_anonymous_extensions(tmpdir):
             with asdf.AsdfFile.open('test.asdf') as ff:
                 assert_tree_match(tree, ff.tree)
 
+        close_fits(hdulist2)
+
 
 def test_create_in_tree_first(tmpdir):
     tree = {
@@ -137,3 +141,5 @@ def test_create_in_tree_first(tmpdir):
         with fits_embed.AsdfInFits.open(hdulist) as ff4:
             assert_array_equal(ff4.tree['model']['sci']['data'],
                                np.arange(512, dtype=np.float))
+
+        close_fits(hdulist)


### PR DESCRIPTION
The `AsdfInFits` class should not be closing the FITS file, since it's passed in and it doesn't "own" it.

Ideally `HDUList.close()` would close and flush all of it's mmap handles, but it doesn't.  Fixing that is sort of a `astropy.io.fits` issue that is sort of non-trivial to fix (see astropy/astropy#3827), and `pyasdf` shouldn't be trying to patch around that with magic.

Here, the magic is moved to the testing functions only just to get `setup.py test --open-files` to not complain.