### PR TITLE
Deferred block finding

### DIFF
--- a/pyasdf/asdf.py
+++ b/pyasdf/asdf.py
@@ -280,7 +280,8 @@ class AsdfFile(versioning.VersionedMixin):
 
             - ``inline``: Store the data as YAML inline in the tree.
         """
-        self.blocks[arr].array_storage = array_storage
+        block = self.blocks[arr]
+        self.blocks.set_array_storage(block, array_storage)
 
     def get_array_storage(self, arr):
         """
@@ -748,9 +749,10 @@ class AsdfFile(versioning.VersionedMixin):
         produces something that, when saved, is a 100% valid YAML
         file.
         """
+        self.blocks.finish_reading_internal_blocks()
         self.resolve_references()
-        for b in self.blocks.blocks:
-            b.array_storage = 'inline'
+        for b in list(self.blocks.blocks):
+            self.blocks.set_array_storage(b, 'inline')
 
     def fill_defaults(self):
         """

--- a/pyasdf/asdf.py
+++ b/pyasdf/asdf.py
@@ -555,6 +555,8 @@ class AsdfFile(versioning.VersionedMixin):
             raise IOError(
                 "Can not update, since associated file is not seekable")
 
+        self.blocks.finish_reading_internal_blocks()
+
         self._pre_write(fd, all_array_storage, all_array_compression,
                         auto_inline)
 

--- a/pyasdf/block.py
+++ b/pyasdf/block.py
@@ -191,11 +191,7 @@ class BlockManager(object):
             if block.array_storage in 'internal':
                 last_block = block
 
-        # If the desired block hasn't already been read, and the
-        # file is seekable, and we have at least one internal
-        # block, then we can move the file pointer to the end of
-        # the last known internal block, and start looking for
-        # more internal blocks.  This is "deferred block loading".
+        # Read all of the remaining blocks in the file, if any
         if (last_block is not None and
             last_block._fd is not None and
             last_block._fd.seekable()):

--- a/pyasdf/block.py
+++ b/pyasdf/block.py
@@ -32,7 +32,18 @@ class BlockManager(object):
     def __init__(self, asdffile):
         self._asdffile = weakref.ref(asdffile)
 
-        self._blocks = []
+        self._internal_blocks = []
+        self._external_blocks = []
+        self._inline_blocks = []
+        self._streamed_blocks = []
+
+        self._block_type_mapping = {
+            'internal': self._internal_blocks,
+            'external': self._external_blocks,
+            'inline': self._inline_blocks,
+            'streamed': self._streamed_blocks
+        }
+
         self._data_to_block_mapping = {}
         self._validate_checksums = False
 
@@ -40,18 +51,28 @@ class BlockManager(object):
         """
         Return the total number of blocks being managed.
 
-        This may not be include all of the blocks in an open file,
-        since their reading may have been deferred.  Call
+        This may not include all of the blocks in an open file, since
+        their reading may have been deferred.  Call
         `finish_reading_internal_blocks` to find the positions and
         header information of all blocks in the file.
         """
-        return len(self._blocks)
+        return sum(len(x) for x in self._block_type_mapping.values())
 
     def add(self, block):
         """
         Add an internal block to the manager.
         """
-        self._blocks.append(block)
+        block_set = self._block_type_mapping.get(block.array_storage, None)
+        if block_set is not None:
+            if block not in block_set:
+                block_set.append(block)
+        else:
+            raise ValueError(
+                "Unknown array storage type {0}".format(block.array_storage))
+
+        if block.array_storage == 'streamed' and len(self._streamed_blocks) > 1:
+            raise ValueError("Can not add second streaming block")
+
         if block._data is not None:
             self._data_to_block_mapping[id(block._data)] = block
 
@@ -59,36 +80,78 @@ class BlockManager(object):
         """
         Remove a block from the manager.
         """
-        self._blocks.remove(block)
-        if block._data is not None:
-            del self._data_to_block_mapping[id(block._data)]
+        block_set = self._block_type_mapping.get(block.array_storage, None)
+        if block_set is not None:
+            if block in block_set:
+                block_set.remove(block)
+                if block._data is not None:
+                    if id(block._data) in self._data_to_block_mapping:
+                        del self._data_to_block_mapping[id(block._data)]
+        else:
+            raise ValueError(
+                "Unknown array storage type {0}".format(block.array_storage))
+
+    def set_array_storage(self, block, array_storage):
+        """
+        Set the array storage type of the given block.
+
+        Parameters
+        ----------
+        block : Block instance
+
+        array_storage : str
+            Must be one of:
+
+            - ``internal``: The default.  The array data will be
+              stored in a binary block in the same ASDF file.
+
+            - ``external``: Store the data in a binary block in a
+              separate ASDF file.
+
+            - ``inline``: Store the data as YAML inline in the tree.
+
+            - ``streamed``: The special streamed inline block that
+              appears at the end of the file.
+        """
+        if array_storage not in ['internal', 'external', 'streamed', 'inline']:
+            raise ValueError(
+                "array_storage must be one of 'internal', 'external', "
+                "'streamed' or 'inline'")
+
+        if block.array_storage != array_storage:
+            if block in self.blocks:
+                self.remove(block)
+            block._array_storage = array_storage
+            self.add(block)
+            if array_storage == 'streamed':
+                block.compression = None
 
     @property
     def blocks(self):
         """
         An iterator over all blocks being managed.
 
-        This may not be include all of the blocks in an open file,
+        This may not include all of the blocks in an open file,
         since their reading may have been deferred.  Call
         `finish_reading_internal_blocks` to find the positions and
         header information of all blocks in the file.
         """
-        for block in self._blocks:
-            yield block
+        for block_set in self._block_type_mapping.values():
+            for block in block_set:
+                yield block
 
     @property
     def internal_blocks(self):
         """
         An iterator over all internal blocks being managed.
 
-        This may not be include all of the blocks in an open file,
+        This may not include all of the blocks in an open file,
         since their reading may have been deferred.  Call
         `finish_reading_internal_blocks` to find the positions and
         header information of all blocks in the file.
         """
-        block = None
-        for block in self._blocks:
-            if block.array_storage in ('internal', 'streamed'):
+        for block_set in (self._internal_blocks, self._streamed_blocks):
+            for block in block_set:
                 yield block
 
     @property
@@ -99,18 +162,24 @@ class BlockManager(object):
         """
         self.finish_reading_internal_blocks()
 
-        for block in self._blocks:
-            if block.array_storage == 'streamed':
-                return block
+        if len(self._streamed_blocks):
+            return self._streamed_blocks[0]
 
     @property
     def external_blocks(self):
         """
         An iterator over all external blocks being managed.
         """
-        for block in self._blocks:
-            if block.array_storage == 'external':
-                yield block
+        for block in self._external_blocks:
+            yield block
+
+    @property
+    def inline_blocks(self):
+        """
+        An iterator over all inline blocks being managed.
+        """
+        for block in self._inline_blocks:
+            yield blocks
 
     def has_blocks_with_offset(self):
         """
@@ -129,7 +198,7 @@ class BlockManager(object):
                 return 0xffffffffffffffff
             else:
                 return x.offset
-        self._blocks.sort(key=sorter)
+        self._internal_blocks.sort(key=sorter)
 
     def _read_next_internal_block(self, fd, past_magic=False):
         # This assumes the file pointer is at the beginning of the
@@ -184,24 +253,19 @@ class BlockManager(object):
         This is called before updating a file, since updating requires
         knowledge of all internal blocks in the file.
         """
-        # First, iterate through the blocks we've already read
-        # to find the last internal block
-        last_block = None
-        for block in self._blocks:
-            if block.array_storage in 'internal':
-                last_block = block
+        if len(self._internal_blocks):
+            last_block = self._internal_blocks[-1]
 
-        # Read all of the remaining blocks in the file, if any
-        if (last_block is not None and
-            last_block._fd is not None and
-            last_block._fd.seekable()):
-            last_block._fd.seek(
-                last_block.offset + last_block.header_size + last_block.allocated)
-            while True:
-                last_block = self._read_next_internal_block(
-                    last_block._fd, False)
-                if last_block is None:
-                    break
+            # Read all of the remaining blocks in the file, if any
+            if (last_block._fd is not None and
+                last_block._fd.seekable()):
+                last_block._fd.seek(
+                    last_block.offset + last_block.header_size + last_block.allocated)
+                while True:
+                    last_block = self._read_next_internal_block(
+                        last_block._fd, False)
+                    if last_block is None:
+                        break
 
     def write_internal_blocks_serial(self, fd, pad_blocks=False):
         """
@@ -282,7 +346,7 @@ class BlockManager(object):
             subfd = self.get_external_uri(uri, i)
             asdffile = asdf.AsdfFile()
             block = copy.copy(block)
-            block.array_storage = 'internal'
+            block._array_storage = 'internal'
             asdffile.blocks.add(block)
             block._used = True
             asdffile.write_to(subfd, pad_blocks=pad_blocks)
@@ -326,7 +390,7 @@ class BlockManager(object):
                 block_to_array_mapping.setdefault(block, [])
                 block_to_array_mapping[block].append(node)
 
-        for block in self._blocks[:]:
+        for block in list(self.blocks):
             arrays = block_to_array_mapping.get(block, [])
             if getattr(block, '_used', 0) == 0 and len(arrays) == 0:
                 self.remove(block)
@@ -334,7 +398,7 @@ class BlockManager(object):
     def _handle_global_block_settings(self, ctx, block):
         all_array_storage = getattr(ctx, '_all_array_storage', None)
         if all_array_storage:
-            block.array_storage = all_array_storage
+            self.set_array_storage(block, all_array_storage)
 
         all_array_compression = getattr(ctx, '_all_array_compression', None)
         if all_array_compression:
@@ -343,7 +407,7 @@ class BlockManager(object):
         auto_inline = getattr(ctx, '_auto_inline', None)
         if auto_inline:
             if np.product(block.data.shape) < auto_inline:
-                block.array_storage = 'inline'
+                self.set_array_storage(block, 'inline')
 
     def finalize(self, ctx):
         """
@@ -357,16 +421,8 @@ class BlockManager(object):
 
         self._find_used_blocks(ctx.tree, ctx)
 
-        for block in self.blocks:
+        for block in list(self.blocks):
             self._handle_global_block_settings(ctx, block)
-
-        count = 0
-        for block in self._blocks:
-            if block.array_storage == 'streamed':
-                count += 1
-        if count > 1:
-            raise ValueError(
-                "Found {0} streamed blocks, but there must be only one.".format(count))
 
     def get_block(self, source):
         """
@@ -385,34 +441,34 @@ class BlockManager(object):
         # If an "int", it is the index of an internal block
         if isinstance(source, int):
             if source == -1:
-                streamed_block = self.streamed_block
-                if streamed_block is not None:
-                    return streamed_block
+                if len(self._streamed_blocks):
+                    return self._streamed_blocks[0]
                 # If we don't have a streamed block, fall through so
                 # we can read all of the blocks, ultimately arriving
                 # at the last one, which, if all goes well is a
                 # streamed block.
 
-            # First, iterate through the blocks we've already read
-            # to look for the block
-            i = 0
-            last_block = None
-            for block in self._blocks:
-                if block.array_storage in ('internal', 'streamed'):
-                    if i == source:
-                        return block
-                    else:
-                        last_block = block
-                        i += 1
+            # First, look in the blocks we've already read
+            elif source >= 0:
+                if source < len(self._internal_blocks):
+                    return self._internal_blocks[source]
+
+            else:
+                raise ValueError("Invalid source id {0}".format(source))
+
+            # If we have a streamed block or we already know we have
+            # no blocks, reading any further isn't going to yield any
+            # new blocks.
+            if len(self._streamed_blocks) or len(self._internal_blocks) == 0:
+                raise ValueError("Block '{0}' not found.".format(source))
 
             # If the desired block hasn't already been read, and the
             # file is seekable, and we have at least one internal
             # block, then we can move the file pointer to the end of
             # the last known internal block, and start looking for
             # more internal blocks.  This is "deferred block loading".
-            if (last_block is not None and
-                last_block.array_storage != 'streamed' and
-                last_block._fd is not None and
+            last_block = self._internal_blocks[-1]
+            if (last_block._fd is not None and
                 last_block._fd.seekable()):
                 last_block._fd.seek(
                     last_block.offset + last_block.header_size +
@@ -422,14 +478,11 @@ class BlockManager(object):
                         last_block._fd, False)
                     if next_block is None:
                         break
-                    if i == source:
+                    if len(self._internal_blocks) - 1 == source:
                         return next_block
-                    else:
-                        i += 1
                     last_block = next_block
 
             if (source == -1 and
-                last_block is not None and
                 last_block.array_storage == 'streamed'):
                 return last_block
 
@@ -438,10 +491,8 @@ class BlockManager(object):
         elif isinstance(source, six.string_types):
             asdffile = self._asdffile().open_external(
                 source, do_not_fill_defaults=True)
-            block = asdffile.blocks._blocks[0]
-            block.array_storage = 'external'
-            if block not in self._blocks:
-                self._blocks.append(block)
+            block = asdffile.blocks._internal_blocks[0]
+            self.set_array_storage(block, 'external')
 
         else:
             raise TypeError("Unknown source '{0}'".format(source))
@@ -520,7 +571,7 @@ class BlockManager(object):
         from .tags.core import ndarray
         if (isinstance(arr, ndarray.NDArrayType) and
             arr.block is not None):
-            if arr.block in self._blocks:
+            if arr.block in self.blocks:
                 return arr.block
             else:
                 arr._block = None
@@ -543,7 +594,7 @@ class BlockManager(object):
         block = self.streamed_block
         if block is None:
             block = Block(array_storage='streamed')
-            self._blocks.append(block)
+            self.add(block)
         return block
 
     def add_inline(self, array):
@@ -558,7 +609,7 @@ class BlockManager(object):
         return self.find_or_create_block_for_array(arr, object())
 
     def close(self):
-        for block in self._blocks:
+        for block in self.blocks:
             block.close()
 
 
@@ -631,16 +682,6 @@ class Block(object):
     @property
     def array_storage(self):
         return self._array_storage
-
-    @array_storage.setter
-    def array_storage(self, typename):
-        if typename not in ['internal', 'external', 'streamed', 'inline']:
-            raise ValueError(
-                "array_storage must be one of 'internal', 'external', "
-                "'streamed' or 'inline'")
-        self._array_storage = typename
-        if typename == 'streamed':
-            self.compression = None
 
     @property
     def compression(self):
@@ -967,14 +1008,13 @@ def calculate_updated_layout(blocks, tree_size, pad_blocks, block_size):
 
     fixed = []
     free = []
-    for block in blocks._blocks:
-        if block.array_storage == 'internal':
-            if block.offset is not None:
-                block.update_size()
-                fixed.append(
-                    Entry(block.offset, block.offset + block.size, block))
-            else:
-                free.append(block)
+    for block in blocks._internal_blocks:
+        if block.offset is not None:
+            block.update_size()
+            fixed.append(
+                Entry(block.offset, block.offset + block.size, block))
+        else:
+            free.append(block)
 
     if not len(fixed):
         return False

--- a/pyasdf/block.py
+++ b/pyasdf/block.py
@@ -388,9 +388,10 @@ class BlockManager(object):
                 streamed_block = self.streamed_block
                 if streamed_block is not None:
                     return streamed_block
-                # If we don't have a streamed block, fall through
-                # so we can read all of the blocks, ultimately arriving
-                # at the last one, which, if all goes well
+                # If we don't have a streamed block, fall through so
+                # we can read all of the blocks, ultimately arriving
+                # at the last one, which, if all goes well is a
+                # streamed block.
 
             # First, iterate through the blocks we've already read
             # to look for the block
@@ -414,7 +415,8 @@ class BlockManager(object):
                 last_block._fd is not None and
                 last_block._fd.seekable()):
                 last_block._fd.seek(
-                    last_block.offset + last_block.header_size + last_block.allocated)
+                    last_block.offset + last_block.header_size +
+                    last_block.allocated)
                 while True:
                     next_block = self._read_next_internal_block(
                         last_block._fd, False)

--- a/pyasdf/tags/core/ndarray.py
+++ b/pyasdf/tags/core/ndarray.py
@@ -221,12 +221,8 @@ class NDArrayType(AsdfType):
         self._block = None
         self._array = None
         self._mask = mask
-        if isinstance(source, int):
-            try:
-                self._block = asdffile.blocks.get_block(source)
-            except ValueError:
-                pass
-        elif isinstance(source, list):
+
+        if isinstance(source, list):
             self._array = inline_data_asarray(source, dtype)
             self._array = self._apply_mask(self._array, self._mask)
             self._block = asdffile.blocks.add_inline(self._array)
@@ -236,6 +232,7 @@ class NDArrayType(AsdfType):
                     (self._array.shape != tuple(shape))):
                     raise ValueError(
                         "inline data doesn't match the given shape")
+
         self._shape = shape
         self._dtype = dtype
         self._offset = offset

--- a/pyasdf/tags/core/ndarray.py
+++ b/pyasdf/tags/core/ndarray.py
@@ -425,7 +425,7 @@ class NDArrayType(AsdfType):
         if isinstance(data, ma.MaskedArray):
             if np.any(data.mask):
                 if block.array_storage == 'inline':
-                    ctx.blocks[data.mask].array_storage = 'inline'
+                    ctx.blocks.set_array_storage(ctx.blocks[data.mask], 'inline')
                 result['mask'] = yamlutil.custom_tree_to_tagged_tree(
                     data.mask, ctx)
 
@@ -472,8 +472,8 @@ class NDArrayType(AsdfType):
     def copy_to_new_asdf(cls, node, asdffile):
         if isinstance(node, NDArrayType):
             array = node._make_array()
-            asdffile.blocks[array].array_storage = \
-                node.block.array_storage
+            asdffile.blocks.set_array_storage(asdffile.blocks[array],
+                                              node.block.array_storage)
             return node._make_array()
         return node
 

--- a/pyasdf/tags/core/tests/test_ndarray.py
+++ b/pyasdf/tags/core/tests/test_ndarray.py
@@ -252,7 +252,7 @@ def test_inline():
     buff = io.BytesIO()
 
     ff = asdf.AsdfFile(tree)
-    ff.blocks[tree['science_data']].array_storage = 'inline'
+    ff.blocks.set_array_storage(ff.blocks[tree['science_data']], 'inline')
     ff.write_to(buff)
 
     buff.seek(0)

--- a/pyasdf/tests/test_low_level.py
+++ b/pyasdf/tests/test_low_level.py
@@ -340,7 +340,7 @@ def test_update_expand_tree(tmpdir):
     }
 
     ff = asdf.AsdfFile(tree)
-    ff.blocks[tree['arrays'][2]].array_storage = 'inline'
+    ff.set_array_storage(tree['arrays'][2], 'inline')
     ff.write_to(testpath, pad_blocks=True)
     with asdf.AsdfFile.open(testpath, mode='rw') as ff:
         assert_array_equal(ff.tree['arrays'][0], my_array)
@@ -356,7 +356,7 @@ def test_update_expand_tree(tmpdir):
 
     # Now, we expand the header only by a little bit
     ff = asdf.AsdfFile(tree)
-    ff.blocks[tree['arrays'][2]].array_storage = 'inline'
+    ff.set_array_storage(tree['arrays'][2], 'inline')
     ff.write_to(os.path.join(tmpdir, "test2.asdf"), pad_blocks=True)
     with asdf.AsdfFile.open(os.path.join(tmpdir, "test2.asdf"), mode='rw') as ff:
         orig_offset = ff.blocks[ff.tree['arrays'][0]].offset
@@ -569,7 +569,6 @@ def test_update_add_array_at_end(tmpdir):
         assert_array_equal(ff.tree['arrays'][1], tree['arrays'][1])
         assert_array_equal(ff.tree['arrays'][2], tree['arrays'][2])
         assert_array_equal(ff.tree['arrays'][3], np.arange(2048))
-        print([x.offset for x in ff.blocks._blocks])
 
 
 def test_update_replace_all_arrays(tmpdir):
@@ -717,8 +716,8 @@ def test_checksum(tmpdir):
     ff.write_to(path)
 
     with asdf.AsdfFile.open(path, validate_checksums=True) as ff:
-        assert type(ff.blocks._blocks[0].checksum) == bytes
-        assert ff.blocks._blocks[0].checksum == \
+        assert type(ff.blocks._internal_blocks[0].checksum) == bytes
+        assert ff.blocks._internal_blocks[0].checksum == \
             b'\xcaM\\\xb8t_L|\x00\n+\x01\xf1\xcfP1'
 
 
@@ -739,7 +738,7 @@ def test_checksum_update(tmpdir):
         ff.update()
 
     with asdf.AsdfFile.open(path, validate_checksums=True) as ff:
-        assert ff.blocks._blocks[0].checksum == \
+        assert ff.blocks._internal_blocks[0].checksum == \
             b'T\xaf~[\x90\x8a\x88^\xc2B\x96D,N\xadL'
 
 

--- a/pyasdf/tests/test_low_level.py
+++ b/pyasdf/tests/test_low_level.py
@@ -790,3 +790,20 @@ def test_copy(tmpdir):
         assert ff.tree['foo']['bar'] == 'baz'
 
     assert_array_equal(ff2.tree['my_array'], ff2.tree['my_array'])
+
+
+def test_deferred_block_loading():
+    buff = io.BytesIO()
+
+    ff = asdf.AsdfFile(_get_small_tree())
+    ff.write_to(buff)
+
+    buff.seek(0)
+    with asdf.AsdfFile.open(buff) as ff2:
+        assert len(ff2.blocks) == 1
+        ff2.blocks.get_block(1)
+
+        assert len(ff2.blocks) == 2
+
+        with pytest.raises(ValueError):
+            ff2.blocks.get_block(2)

--- a/pyasdf/tests/test_schema.py
+++ b/pyasdf/tests/test_schema.py
@@ -115,8 +115,11 @@ def test_all_schema_examples():
                     os.path.join(os.path.dirname(fname), 'external.asdf')))] = ff2
 
         # Add some dummy blocks so that the ndarray examples work
-        for i in range(2):
-            ff.blocks.add(block.Block(np.empty((1024*1024*8), dtype=np.uint8)))
+        for i in range(3):
+            b = block.Block(np.empty((1024*1024*8), dtype=np.uint8))
+            b._used = True
+            ff.blocks.add(b)
+        b._array_storage = "streamed"
 
         try:
             ff._open_impl(ff, buff)

--- a/pyasdf/tests/test_stream.py
+++ b/pyasdf/tests/test_stream.py
@@ -157,7 +157,7 @@ def test_array_to_stream(tmpdir):
 
     buff = io.BytesIO()
     ff = asdf.AsdfFile(tree)
-    ff.blocks[tree['stream']].array_storage = 'streamed'
+    ff.set_array_storage(tree['stream'], 'streamed')
     ff.write_to(buff)
     buff.write(np.array([5, 6, 7, 8], np.int64).tostring())
 
@@ -171,7 +171,7 @@ def test_array_to_stream(tmpdir):
 
     with open(os.path.join(str(tmpdir), 'test.asdf'), 'wb') as fd:
         ff = asdf.AsdfFile(tree)
-        ff.blocks[tree['stream']].array_storage = 'streamed'
+        ff.set_array_storage(tree['stream'], 'streamed')
         ff.write_to(fd)
         fd.write(np.array([5, 6, 7, 8], np.int64).tostring())
 
@@ -188,10 +188,7 @@ def test_too_many_streams():
         'stream2': np.array([1, 2, 3, 4], np.int64)
     }
 
-    buff = io.BytesIO()
-
     ff = asdf.AsdfFile(tree)
-    ff.blocks[tree['stream1']].array_storage = 'streamed'
-    ff.blocks[tree['stream2']].array_storage = 'streamed'
+    ff.set_array_storage(tree['stream1'], 'streamed')
     with pytest.raises(ValueError):
-        ff.write_to(buff)
+        ff.set_array_storage(tree['stream2'], 'streamed')

--- a/pyasdf/tests/test_stream.py
+++ b/pyasdf/tests/test_stream.py
@@ -95,9 +95,10 @@ def test_stream_with_nonstream():
     buff.seek(0)
 
     with asdf.AsdfFile().open(buff) as ff:
-        assert len(ff.blocks) == 2
+        assert len(ff.blocks) == 1
         assert_array_equal(ff.tree['nonstream'], np.array([1, 2, 3, 4], np.int64))
         assert ff.tree['stream'].shape == (100, 6, 2)
+        assert len(ff.blocks) == 2
         for i, row in enumerate(ff.tree['stream']):
             assert np.all(row == i)
 
@@ -117,9 +118,10 @@ def test_stream_real_file(tmpdir):
             fd.write(np.array([i] * 12, np.float64).tostring())
 
     with asdf.AsdfFile().open(path) as ff:
-        assert len(ff.blocks) == 2
+        assert len(ff.blocks) == 1
         assert_array_equal(ff.tree['nonstream'], np.array([1, 2, 3, 4], np.int64))
         assert ff.tree['stream'].shape == (100, 6, 2)
+        assert len(ff.blocks) == 2
         for i, row in enumerate(ff.tree['stream']):
             assert np.all(row == i)
 


### PR DESCRIPTION
The current behavior is to find all blocks in the ASDF file by "skipping" along their headers immediately upon opening the file.  While it isn't reading (or even memmapping) all of the data, it is skipping along the file to read the block headers, and if there's a lot of blocks, that overhead could be significant (particularly over a network file system or HTTP with Range headers).

This changes things so the block headers are read lazily when a particular block is requested.  This still isn't random access, since all block headers leading up to a particular block must still be read.  For example, if block 9 of 20 is requested, block headers 0-9 will be read (and cached along the way for later use, so requesting block header 4 afterward wouldn't even hit the disk).

The first block header is always read, since we've usually read that area anyway when finding the end of the YAML tree.

I still plan to implement some sort of an index so that block access can truly be O(1), but I think it will always be the case that we want to support ASDF files without such an index, and that might as well perform as well as we can make it...

Cc: @embray