### PR TITLE
Roundtrip datetime as datetime

### DIFF
--- a/pyasdf/tags/core/tests/test_history.py
+++ b/pyasdf/tags/core/tests/test_history.py
@@ -3,6 +3,8 @@
 
 from __future__ import absolute_import, division, unicode_literals, print_function
 
+import datetime
+
 from astropy.tests.helper import pytest
 
 from jsonschema import ValidationError
@@ -29,3 +31,5 @@ def test_history():
 
     ff.add_history_entry('This other thing happened')
     assert len(ff.tree['history']) == 2
+
+    assert isinstance(ff.tree['history'][0]['time'], datetime.datetime)

--- a/pyasdf/tags/time/time.py
+++ b/pyasdf/tags/time/time.py
@@ -3,8 +3,6 @@
 
 from __future__ import absolute_import, division, unicode_literals, print_function
 
-import datetime
-
 import numpy as np
 
 from astropy.extern import six
@@ -28,13 +26,10 @@ _astropy_format_to_asdf_format = {
 
 class TimeType(AsdfType):
     name = 'time/time'
-    types = [time.core.Time, datetime.datetime]
+    types = [time.core.Time]
 
     @classmethod
     def to_tree(cls, node, ctx):
-        if isinstance(node, datetime.datetime):
-            node = time.Time(node)
-
         format = node.format
 
         if format == 'byear':


### PR DESCRIPTION
This fixes a problem where datetime objects were not roundtripped as
datetime objects.  This also removes a dependency on astropy for time if
you don't care about all the complexities that astropy.time supports.