### PR TITLE
Support optional dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ install:
     # install since this ensures Numpy does not get automatically upgraded.
     # - if [[ $SETUP_CMD != egg_info ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION ... ; fi
     # - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL ...; fi
-    - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL jsonschema pyyaml; fi
+    - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL jsonschema pyyaml six; fi
 
     # DOCUMENTATION DEPENDENCIES
     # build_sphinx needs sphinx and matplotlib (for plot_directive). Note that

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,7 +41,7 @@ install:
     - "python --version"
 
     # Install specified version of numpy and dependencies
-    - "conda install -q --yes numpy=%NUMPY_VERSION% pytest Cython jinja2 pyyaml jsonschema psutil"
+    - "conda install -q --yes numpy=%NUMPY_VERSION% pytest Cython jinja2 pyyaml jsonschema psutil six"
 
     # Install the development version of astropy
     - "%CMD_IN_ENV% pip install git+http://github.com/astropy/astropy.git#egg=astropy"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,11 +11,17 @@ Installation
 
 - `numpy <http://www.numpy.org/>`__ 1.6 or later
 
-- `astropy <http://www.astropy.org/>`__ 1.0 or later
-
 - `jsonschema <http://python-jsonschema.readthedocs.org/>`__ 2.3.0 or later
 
 - `pyyaml <http://pyyaml.org>`__ 3.10 or later
+
+- `six <https://pypi.python.org/pypi/six>`__ 1.9.0 or later
+
+Support for units, time, transform, wcs, or running the tests also
+requires:
+
+- `astropy <http://www.astropy.org/>`__ 1.0 or later
+
 
 Getting Started
 ---------------

--- a/pyasdf/__init__.py
+++ b/pyasdf/__init__.py
@@ -11,10 +11,10 @@ Data Format (ASDF) files
 # Affiliated packages may add whatever they like to this file, but
 # should keep this content at the top.
 # ----------------------------------------------------------------------------
-from ._astropy_init import *
+from ._internal_init import *
 # ----------------------------------------------------------------------------
 
-if _ASTROPY_SETUP_ is False:
+if _PYASDF_SETUP_ is False:
     __all__ = ['AsdfFile', 'AsdfType', 'AsdfExtension',
                'Stream', 'open', 'test', 'commands',
                'ValidationError']
@@ -33,11 +33,6 @@ if _ASTROPY_SETUP_ is False:
         import numpy as _
     except ImportError:
         raise ImportError("pyasdf requires numpy")
-
-    try:
-        import astropy as _
-    except ImportError:
-        raise ImportError("pyasdf requires astropy")
 
     from .asdf import AsdfFile
     from .asdftypes import AsdfType

--- a/pyasdf/_internal_init.py
+++ b/pyasdf/_internal_init.py
@@ -7,14 +7,14 @@ __all__ = ['__version__', '__githash__', 'test']
 
 # this indicates whether or not we are in the package's setup.py
 try:
-    _ASTROPY_SETUP_
+    _PYASDF_SETUP_
 except NameError:
     from sys import version_info
     if version_info[0] >= 3:
         import builtins
     else:
         import __builtin__ as builtins
-    builtins._ASTROPY_SETUP_ = False
+    builtins._PYASDF_SETUP_ = False
 
 try:
     from .version import version as __version__
@@ -108,37 +108,14 @@ def test(package=None, test_path=None, args=None, plugins=None,
         explicitly updating the package template.
 
     """
+    try:
+        import astropy
+    except ImportError:
+        raise ImportError("Running the tests requires astropy")
+
     test_runner = _get_test_runner()
     return test_runner.run_tests(
         package=package, test_path=test_path, args=args,
         plugins=plugins, verbose=verbose, pastebin=pastebin,
         remote_data=remote_data, pep8=pep8, pdb=pdb,
         coverage=coverage, open_files=open_files, **kwargs)
-
-
-if not _ASTROPY_SETUP_:
-    import os
-    from warnings import warn
-    from astropy import config
-
-    # add these here so we only need to cleanup the namespace at the end
-    config_dir = None
-
-    if not os.environ.get('ASTROPY_SKIP_CONFIG_UPDATE', False):
-        config_dir = os.path.dirname(__file__)
-        config_template = os.path.join(config_dir, __package__ + ".cfg")
-        if os.path.isfile(config_template):
-            try:
-                config.configuration.update_default_config(
-                    __package__, config_dir, version=__version__)
-            except TypeError as orig_error:
-                try:
-                    config.configuration.update_default_config(
-                        __package__, config_dir)
-                except config.configuration.ConfigurationDefaultMissingError as e:
-                    wmsg = (e.args[0] + " Cannot install default profile. If you are "
-                            "importing from source, this is expected.")
-                    warn(config.configuration.ConfigurationDefaultMissingWarning(wmsg))
-                    del e
-                except:
-                    raise orig_error

--- a/pyasdf/block.py
+++ b/pyasdf/block.py
@@ -14,13 +14,13 @@ import weakref
 
 import numpy as np
 
-from astropy.extern import six
-from astropy.extern.six.moves.urllib import parse as urlparse
-from astropy.utils.compat import NUMPY_LT_1_7
+import six
+from six.moves.urllib import parse as urlparse
 
 import yaml
 
 from . import compression as mcompression
+from .compat.numpycompat import NUMPY_LT_1_7
 from . import constants
 from . import generic_io
 from . import stream

--- a/pyasdf/commands/main.py
+++ b/pyasdf/commands/main.py
@@ -5,10 +5,10 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import argparse
+import logging
 import sys
 
-from astropy.extern import six
-from astropy.logger import log
+import six
 
 from .. import util
 
@@ -80,10 +80,10 @@ def main_from_args(args):
     try:
         result = args.func(args)
     except RuntimeError as e:
-        log.error(six.text_type(e))
+        logging.error(six.text_type(e))
         return 1
     except IOError as e:
-        log.error(six.text_type(e))
+        logging.error(six.text_type(e))
         return e.errno
 
     if result is None:

--- a/pyasdf/commands/tests/test_main.py
+++ b/pyasdf/commands/tests/test_main.py
@@ -3,7 +3,7 @@
 
 from __future__ import absolute_import, division, unicode_literals, print_function
 
-from astropy.tests.helper import pytest
+import pytest
 
 from .. import main
 

--- a/pyasdf/compat/__init__.py
+++ b/pyasdf/compat/__init__.py
@@ -3,7 +3,7 @@
 
 from __future__ import absolute_import, division, unicode_literals, print_function
 
-from astropy.extern import six
+import six
 
 if six.PY2:
     from UserDict import UserDict

--- a/pyasdf/compat/_odict_py2/__init__.py
+++ b/pyasdf/compat/_odict_py2/__init__.py
@@ -1,0 +1,190 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Backport of the Python 2.7 collections.OrderedDict class to Python 2.6.
+
+Ordered dictionaries are just like regular dictionaries but they remember the
+order that items were inserted.  When iterating over an ordered dictionary,
+the items are returned in the order their keys were first added.
+
+See: http://docs.python.org/library/collections.html#collections.OrderedDict
+"""
+
+from __future__ import absolute_import
+
+__all__ = ['OrderedDict']
+
+from collections import MutableMapping
+from operator import eq as _eq
+from itertools import imap as _imap
+
+try:
+    from thread import get_ident
+except ImportError:
+    from dummy_thread import get_ident
+
+
+def _recursive_repr(user_function):
+    'Decorator to make a repr function return "..." for a recursive call'
+    repr_running = set()
+
+    def wrapper(self):
+        key = id(self), get_ident()
+        if key in repr_running:
+            return '...'
+        repr_running.add(key)
+        try:
+            result = user_function(self)
+        finally:
+            repr_running.discard(key)
+        return result
+
+    # Can't use functools.wraps() here because of bootstrap issues
+    wrapper.__module__ = getattr(user_function, '__module__')
+    wrapper.__doc__ = getattr(user_function, '__doc__')
+    wrapper.__name__ = getattr(user_function, '__name__')
+    return wrapper
+
+class OrderedDict(dict, MutableMapping):
+    'Dictionary that remembers insertion order'
+    # An inherited dict maps keys to values.
+    # The inherited dict provides __getitem__, __len__, __contains__, and get.
+    # The remaining methods are order-aware.
+    # Big-O running times for all methods are the same as for regular dictionaries.
+
+    # The internal self.__map dictionary maps keys to links in a doubly linked list.
+    # The circular doubly linked list starts and ends with a sentinel element.
+    # The sentinel element never gets deleted (this simplifies the algorithm).
+    # Each link is stored as a list of length three:  [PREV, NEXT, KEY].
+
+    def __init__(self, *args, **kwds):
+        '''Initialize an ordered dictionary.  Signature is the same as for
+        regular dictionaries, but keyword arguments are not recommended
+        because their insertion order is arbitrary.
+
+        '''
+        if len(args) > 1:
+            raise TypeError('expected at most 1 arguments, got %d' % len(args))
+        try:
+            self.__root
+        except AttributeError:
+            self.__root = root = [None, None, None]     # sentinel node
+            PREV = 0
+            NEXT = 1
+            root[PREV] = root[NEXT] = root
+            self.__map = {}
+        self.update(*args, **kwds)
+
+    def __setitem__(self, key, value, PREV=0, NEXT=1, dict_setitem=dict.__setitem__):
+        'od.__setitem__(i, y) <==> od[i]=y'
+        # Setting a new item creates a new link which goes at the end of the linked
+        # list, and the inherited dictionary is updated with the new key/value pair.
+        if key not in self:
+            root = self.__root
+            last = root[PREV]
+            last[NEXT] = root[PREV] = self.__map[key] = [last, root, key]
+        dict_setitem(self, key, value)
+
+    def __delitem__(self, key, PREV=0, NEXT=1, dict_delitem=dict.__delitem__):
+        'od.__delitem__(y) <==> del od[y]'
+        # Deleting an existing item uses self.__map to find the link which is
+        # then removed by updating the links in the predecessor and successor nodes.
+        dict_delitem(self, key)
+        link = self.__map.pop(key)
+        link_prev = link[PREV]
+        link_next = link[NEXT]
+        link_prev[NEXT] = link_next
+        link_next[PREV] = link_prev
+
+    def __iter__(self, NEXT=1, KEY=2):
+        'od.__iter__() <==> iter(od)'
+        # Traverse the linked list in order.
+        root = self.__root
+        curr = root[NEXT]
+        while curr is not root:
+            yield curr[KEY]
+            curr = curr[NEXT]
+
+    def __reversed__(self, PREV=0, KEY=2):
+        'od.__reversed__() <==> reversed(od)'
+        # Traverse the linked list in reverse order.
+        root = self.__root
+        curr = root[PREV]
+        while curr is not root:
+            yield curr[KEY]
+            curr = curr[PREV]
+
+    def __reduce__(self):
+        'Return state information for pickling'
+        items = [[k, self[k]] for k in self]
+        tmp = self.__map, self.__root
+        del self.__map, self.__root
+        inst_dict = vars(self).copy()
+        self.__map, self.__root = tmp
+        if inst_dict:
+            return (self.__class__, (items,), inst_dict)
+        return self.__class__, (items,)
+
+    def clear(self):
+        'od.clear() -> None.  Remove all items from od.'
+        try:
+            for node in self.__map.itervalues():
+                del node[:]
+            self.__root[:] = [self.__root, self.__root, None]
+            self.__map.clear()
+        except AttributeError:
+            pass
+        dict.clear(self)
+
+    setdefault = MutableMapping.setdefault
+    update = MutableMapping.update
+    pop = MutableMapping.pop
+    keys = MutableMapping.keys
+    values = MutableMapping.values
+    items = MutableMapping.items
+    iterkeys = MutableMapping.iterkeys
+    itervalues = MutableMapping.itervalues
+    iteritems = MutableMapping.iteritems
+    __ne__ = MutableMapping.__ne__
+
+    def popitem(self, last=True):
+        '''od.popitem() -> (k, v), return and remove a (key, value) pair.
+        Pairs are returned in LIFO order if last is true or FIFO order if false.
+
+        '''
+        if not self:
+            raise KeyError('dictionary is empty')
+        key = next(reversed(self) if last else iter(self))
+        value = self.pop(key)
+        return key, value
+
+    @_recursive_repr
+    def __repr__(self):
+        'od.__repr__() <==> repr(od)'
+        if not self:
+            return '%s()' % (self.__class__.__name__,)
+        return '%s(%r)' % (self.__class__.__name__, self.items())
+
+    def copy(self):
+        'od.copy() -> a shallow copy of od'
+        return self.__class__(self)
+
+    @classmethod
+    def fromkeys(cls, iterable, value=None):
+        '''OD.fromkeys(S[, v]) -> New ordered dictionary with keys from S
+        and values equal to v (which defaults to None).
+
+        '''
+        d = cls()
+        for key in iterable:
+            d[key] = value
+        return d
+
+    def __eq__(self, other):
+        '''od.__eq__(y) <==> od==y.  Comparison to another OD is order-sensitive
+        while comparison to a regular mapping is order-insensitive.
+
+        '''
+        if isinstance(other, OrderedDict):
+            return len(self)==len(other) and \
+                   all(_imap(_eq, self.iteritems(), other.iteritems()))
+        return dict.__eq__(self, other)

--- a/pyasdf/compat/numpycompat.py
+++ b/pyasdf/compat/numpycompat.py
@@ -1,0 +1,10 @@
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+from ..util import minversion
+
+
+__all__ = ['NUMPY_LT_1_7']
+
+
+NUMPY_LT_1_7 = not minversion('numpy', '1.7.0')

--- a/pyasdf/compat/odict.py
+++ b/pyasdf/compat/odict.py
@@ -1,0 +1,7 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import
+
+try:
+    from collections import OrderedDict
+except ImportError:
+    from ._odict_py2 import *

--- a/pyasdf/compression.py
+++ b/pyasdf/compression.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 
 import numpy as np
 
-from astropy.extern import six
+import six
 
 
 def validate(compression):

--- a/pyasdf/conftest.py
+++ b/pyasdf/conftest.py
@@ -3,7 +3,7 @@
 
 from __future__ import absolute_import, division, unicode_literals, print_function
 
-# this contains imports plugins that configure py.test for astropy tests.
+# this contains imports plugins that configure py.test for pyasdf tests.
 # by importing them here in conftest.py they are discoverable by py.test
 # no matter how it is invoked within the source tree.
 
@@ -16,10 +16,11 @@ enable_deprecations_as_exceptions()
 try:
     PYTEST_HEADER_MODULES['jsonschema'] = 'jsonschema'
     PYTEST_HEADER_MODULES['pyyaml'] = 'yaml'
+    PYTEST_HEADER_MODULES['six'] = 'six'
     del PYTEST_HEADER_MODULES['h5py']
     del PYTEST_HEADER_MODULES['Matplotlib']
     del PYTEST_HEADER_MODULES['Scipy']
-except NameError:  # needed to support Astropy < 1.0
+except NameError:
     pass
 
 
@@ -28,8 +29,9 @@ import os
 import shutil
 import tempfile
 
-from astropy.extern import six
-from astropy.tests.helper import pytest
+import pytest
+
+import six
 
 from .extern.RangeHTTPServer import RangeHTTPRequestHandler
 

--- a/pyasdf/extension.py
+++ b/pyasdf/extension.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 
 import abc
 
-from astropy.extern import six
+import six
 
 from . import asdftypes
 from . import resolver

--- a/pyasdf/extern/RangeHTTPServer.py
+++ b/pyasdf/extern/RangeHTTPServer.py
@@ -31,15 +31,11 @@ __version__ = "0.1"
 
 __all__ = ["RangeHTTPRequestHandler"]
 
-import io
 import os
 import posixpath
-import urllib
-import cgi
 import shutil
-import mimetypes
 
-from astropy.extern import six
+import six
 
 
 class RangeHTTPRequestHandler(six.moves.BaseHTTPServer.BaseHTTPRequestHandler):  # pragma: no cover

--- a/pyasdf/extern/atomicfile.py
+++ b/pyasdf/extern/atomicfile.py
@@ -1,4 +1,4 @@
-from astropy.extern import six
+import six
 
 import os
 import tempfile

--- a/pyasdf/fits_embed.py
+++ b/pyasdf/fits_embed.py
@@ -11,12 +11,16 @@ import re
 
 import numpy as np
 
-from astropy.extern import six
-from astropy.io import fits
+import six
 
 from . import asdf
 from . import block
 from . import util
+
+try:
+    from astropy.io import fits
+except ImportError:
+    raise ImportError("AsdfInFits requires astropy")
 
 
 ASDF_EXTENSION_NAME = 'ASDF'

--- a/pyasdf/generic_io.py
+++ b/pyasdf/generic_io.py
@@ -22,11 +22,10 @@ import tempfile
 
 from os import SEEK_SET, SEEK_CUR, SEEK_END
 
-from astropy.extern import six
-from astropy.extern.six.moves import xrange
-from astropy.extern.six.moves.urllib import parse as urlparse
-from astropy.extern.six.moves.urllib.request import url2pathname
-from astropy.utils.misc import InheritDocstrings
+import six
+from six.moves import xrange
+from six.moves.urllib import parse as urlparse
+from six.moves.urllib.request import url2pathname
 
 import numpy as np
 
@@ -234,7 +233,7 @@ class _TruncatedReader(object):
         return content
 
 
-@six.add_metaclass(InheritDocstrings)
+@six.add_metaclass(util.InheritDocstrings)
 class GenericFile(object):
     """
     Base class for an abstraction layer around a number of different
@@ -1023,7 +1022,7 @@ def _make_http_connection(init, mode, uri=None):
     Creates a HTTPConnection instance if the HTTP server supports
     Range requests, otherwise falls back to a generic InputStream.
     """
-    from astropy.extern.six.moves import http_client
+    from six.moves import http_client
 
     parsed = urlparse.urlparse(init)
     connection = http_client.HTTPConnection(parsed.netloc)

--- a/pyasdf/reference.py
+++ b/pyasdf/reference.py
@@ -14,7 +14,7 @@ import weakref
 
 import numpy as np
 
-from astropy.extern.six.moves.urllib import parse as urlparse
+from six.moves.urllib import parse as urlparse
 
 from .asdftypes import AsdfType
 from . import generic_io

--- a/pyasdf/resolver.py
+++ b/pyasdf/resolver.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 
 import os.path
 
-from astropy.extern import six
+import six
 
 from . import constants
 from . import util

--- a/pyasdf/schema.py
+++ b/pyasdf/schema.py
@@ -7,9 +7,8 @@ import datetime
 import json
 import os
 
-from astropy.extern import six
-from astropy.utils.compat.odict import OrderedDict
-from astropy.extern.six.moves.urllib import parse as urlparse
+import six
+from six.moves.urllib import parse as urlparse
 
 from jsonschema import validators as mvalidators
 from jsonschema.exceptions import ValidationError
@@ -17,6 +16,7 @@ from jsonschema.exceptions import ValidationError
 import yaml
 
 from .compat import lru_cache
+from .compat.odict import OrderedDict
 from . import constants
 from . import generic_io
 from . import reference

--- a/pyasdf/tagged.py
+++ b/pyasdf/tagged.py
@@ -33,8 +33,8 @@ is not intended to be exposed to the end user.
 
 from __future__ import absolute_import, division, unicode_literals, print_function
 
+import six
 
-from astropy.extern import six
 from .compat import UserDict, UserList, UserString
 
 

--- a/pyasdf/tags/core/complex.py
+++ b/pyasdf/tags/core/complex.py
@@ -3,7 +3,7 @@
 
 from __future__ import absolute_import, division, unicode_literals, print_function
 
-from astropy.extern import six
+import six
 
 import numpy as np
 

--- a/pyasdf/tags/core/ndarray.py
+++ b/pyasdf/tags/core/ndarray.py
@@ -9,7 +9,7 @@ from numpy import ma
 
 from jsonschema import ValidationError
 
-from astropy.extern import six
+import six
 
 from ...asdftypes import AsdfType
 from ... import schema

--- a/pyasdf/tags/core/tests/setup_package.py
+++ b/pyasdf/tags/core/tests/setup_package.py
@@ -6,4 +6,4 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 
 def get_package_data():  # pragma: no cover
     return {
-        str(_ASTROPY_PACKAGE_NAME_ + '.tags.core.tests'): ['data/*.yaml']}
+        str(_PACKAGE_NAME_ + '.tags.core.tests'): ['data/*.yaml']}

--- a/pyasdf/tags/core/tests/test_complex.py
+++ b/pyasdf/tags/core/tests/test_complex.py
@@ -3,7 +3,7 @@
 
 from __future__ import absolute_import, division, unicode_literals, print_function
 
-from astropy.tests.helper import pytest
+import pytest
 
 from .... import asdf
 

--- a/pyasdf/tags/core/tests/test_history.py
+++ b/pyasdf/tags/core/tests/test_history.py
@@ -3,6 +3,8 @@
 
 from __future__ import absolute_import, division, unicode_literals, print_function
 
+import datetime
+
 from astropy.tests.helper import pytest
 
 from jsonschema import ValidationError
@@ -29,3 +31,5 @@ def test_history():
 
     ff.add_history_entry('This other thing happened')
     assert len(ff.tree['history']) == 2
+
+    assert isinstance(ff.tree['history'][0]['time'], datetime.datetime)

--- a/pyasdf/tags/core/tests/test_history.py
+++ b/pyasdf/tags/core/tests/test_history.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 
 import datetime
 
-from astropy.tests.helper import pytest
+import pytest
 
 from jsonschema import ValidationError
 

--- a/pyasdf/tags/core/tests/test_ndarray.py
+++ b/pyasdf/tags/core/tests/test_ndarray.py
@@ -15,8 +15,15 @@ except ImportError:
 else:
     HAS_PSUTIL = True
 
-from astropy.extern import six
-from astropy.tests.helper import pytest
+import six
+import pytest
+
+try:
+    import astropy
+except ImportError:
+    HAS_ASTROPY = False
+else:
+    HAS_ASTROPY = True
 
 import numpy as np
 from numpy import ma
@@ -176,6 +183,7 @@ def test_table_inline(tmpdir):
         tree, tmpdir, None, check_raw_yaml, {'auto_inline': 64})
 
 
+@pytest.mark.skipif('not HAS_ASTROPY')
 def test_auto_inline_recursive(tmpdir):
     from astropy.modeling import models
     aff = models.AffineTransformation2D(matrix=[[1, 2], [3, 4]])

--- a/pyasdf/tags/fits/fits.py
+++ b/pyasdf/tags/fits/fits.py
@@ -3,7 +3,6 @@
 
 from __future__ import absolute_import, division, unicode_literals, print_function
 
-from astropy.io import fits
 import numpy as np
 
 from ...asdftypes import AsdfType
@@ -12,10 +11,13 @@ from ... import yamlutil
 
 class FitsType(AsdfType):
     name = 'fits/fits'
-    types = [fits.HDUList]
+    types = ['astropy.io.fits.HDUList']
+    requires = ['astropy']
 
     @classmethod
     def from_tree(cls, data, ctx):
+        from astropy.io import fits
+
         hdus = []
         first = True
         for hdu_entry in data:

--- a/pyasdf/tags/fits/tests/test_fits.py
+++ b/pyasdf/tags/fits/tests/test_fits.py
@@ -3,14 +3,26 @@
 
 from __future__ import absolute_import, division, unicode_literals, print_function
 
-from astropy.io import fits
-from astropy.utils.data import get_pkg_data_filename
+try:
+    import astropy
+except ImportError:
+    HAS_ASTROPY = False
+else:
+    HAS_ASTROPY = True
+
+import pytest
+
+import os
 
 from ....tests import helpers
 
 
+@pytest.mark.skipif('not HAS_ASTROPY')
 def test_complex_structure(tmpdir):
-    with fits.open(get_pkg_data_filename('data/complex.fits'), memmap=False) as hdulist:
+    from astropy.io import fits
+
+    with fits.open(os.path.join(
+            os.path.dirname(__file__), 'data', 'complex.fits'), memmap=False) as hdulist:
         tree = {
             'fits': hdulist
             }

--- a/pyasdf/tags/time/tests/test_time.py
+++ b/pyasdf/tags/time/tests/test_time.py
@@ -3,16 +3,26 @@
 
 from __future__ import absolute_import, division, unicode_literals, print_function
 
-from astropy.extern import six
-from astropy import time
+import six
+
+try:
+    import astropy
+except ImportError:
+    HAS_ASTROPY = False
+else:
+    HAS_ASTROPY = True
+    from astropy import time
 
 import numpy as np
+
+import pytest
 
 from .... import asdf
 from .... import yamlutil
 from ....tests import helpers
 
 
+@pytest.mark.skipif('not HAS_ASTROPY')
 def test_time(tmpdir):
     time_array = time.Time(
         np.arange(100), format="unix")
@@ -24,6 +34,7 @@ def test_time(tmpdir):
     helpers.assert_roundtrip_tree(tree, tmpdir)
 
 
+@pytest.mark.skipif('not HAS_ASTROPY')
 def test_isot(tmpdir):
     tree = {
         'time': time.Time('2000-01-01T00:00:00.000')

--- a/pyasdf/tags/time/time.py
+++ b/pyasdf/tags/time/time.py
@@ -5,9 +5,7 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 
 import numpy as np
 
-from astropy.extern import six
-from astropy import time
-from astropy import units as u
+import six
 
 from ...asdftypes import AsdfType
 from ... import yamlutil
@@ -23,13 +21,15 @@ _astropy_format_to_asdf_format = {
 }
 
 
-
 class TimeType(AsdfType):
     name = 'time/time'
-    types = [time.core.Time]
+    types = ['astropy.time.core.Time']
+    requires = ['astropy']
 
     @classmethod
     def to_tree(cls, node, ctx):
+        from astropy import time
+
         format = node.format
 
         if format == 'byear':
@@ -73,6 +73,9 @@ class TimeType(AsdfType):
 
     @classmethod
     def from_tree(cls, node, ctx):
+        from astropy import time
+        from astropy import units as u
+
         if isinstance(node, (six.string_types, list, np.ndarray)):
             t = time.Time(node)
             format = _astropy_format_to_asdf_format.get(t.format, t.format)

--- a/pyasdf/tags/time/time.py
+++ b/pyasdf/tags/time/time.py
@@ -3,8 +3,6 @@
 
 from __future__ import absolute_import, division, unicode_literals, print_function
 
-import datetime
-
 import numpy as np
 
 from astropy.extern import six
@@ -28,13 +26,10 @@ _astropy_format_to_asdf_format = {
 
 class TimeType(AsdfType):
     name = 'time/time'
-    types = [time.core.Time, datetime.datetime]
+    types = [time.core.Time]
 
     @classmethod
     def to_tree(cls, node, ctx):
-        if isinstance(node, datetime.datetime):
-            node = time.Time(node)
-
         format = node.format
 
         if format == 'byear':

--- a/pyasdf/tags/transform/basic.py
+++ b/pyasdf/tags/transform/basic.py
@@ -3,19 +3,25 @@
 
 from __future__ import absolute_import, division, unicode_literals, print_function
 
-from astropy.modeling import mappings
-from astropy.modeling import functional_models
+try:
+    import astropy
+except ImportError:
+    HAS_ASTROPY = False
+else:
+    HAS_ASTROPY = True
+    from astropy.modeling import mappings
 
 from ...asdftypes import AsdfType
 from ... import tagged
 from ... import yamlutil
 
 __all__ = ['TransformType', 'IdentityType', 'ConstantType',
-           'DomainType', 'GenericModel', 'GenericType']
+           'DomainType']
 
 
 class TransformType(AsdfType):
     name = "transform/transform"
+    requires = ['astropy']
 
     @classmethod
     def _from_tree_base_transform_members(cls, model, node, ctx):
@@ -35,7 +41,8 @@ class TransformType(AsdfType):
 
     @classmethod
     def from_tree_transform(cls, node, ctx):
-        raise NotImplementedError("Must be implemented in TransformType subclasses")
+        raise NotImplementedError(
+            "Must be implemented in TransformType subclasses")
 
     @classmethod
     def from_tree(cls, node, ctx):
@@ -79,7 +86,7 @@ class TransformType(AsdfType):
 
 class IdentityType(TransformType):
     name = "transform/identity"
-    types = [mappings.Identity]
+    types = ['astropy.modeling.mappings.Identity']
 
     @classmethod
     def from_tree_transform(cls, node, ctx):
@@ -94,6 +101,7 @@ class IdentityType(TransformType):
 
     @classmethod
     def assert_equal(cls, a, b):
+        from astropy.modeling import mappings
         # TODO: If models become comparable themselves, remove this.
         TransformType.assert_equal(a, b)
         assert (isinstance(a, mappings.Identity) and
@@ -103,10 +111,12 @@ class IdentityType(TransformType):
 
 class ConstantType(TransformType):
     name = "transform/constant"
-    types = [functional_models.Const1D]
+    types = ['astropy.modeling.functional_models.Const1D']
 
     @classmethod
     def from_tree_transform(cls, node, ctx):
+        from astropy.modeling import functional_models
+
         return functional_models.Const1D(node['value'])
 
     @classmethod
@@ -129,16 +139,18 @@ class DomainType(AsdfType):
 
 
 # TODO: This is just here for bootstrapping and will go away eventually
-class GenericModel(mappings.Mapping):
-    def __init__(self, n_inputs, n_outputs):
-        mapping = tuple(range(n_inputs))
-        super(GenericModel, self).__init__(mapping)
-        self._outputs = tuple('x' + str(idx) for idx in range(self.n_outputs + 1))
+if HAS_ASTROPY:
+    class GenericModel(mappings.Mapping):
+        def __init__(self, n_inputs, n_outputs):
+            mapping = tuple(range(n_inputs))
+            super(GenericModel, self).__init__(mapping)
+            self._outputs = tuple('x' + str(idx) for idx in range(self.n_outputs + 1))
 
 
 class GenericType(TransformType):
     name = "transform/generic"
-    types = [GenericModel]
+    if HAS_ASTROPY:
+        types = [GenericModel]
 
     @classmethod
     def from_tree_transform(cls, node, ctx):

--- a/pyasdf/tags/transform/compound.py
+++ b/pyasdf/tags/transform/compound.py
@@ -3,10 +3,7 @@
 
 from __future__ import absolute_import, division, unicode_literals, print_function
 
-from astropy.extern import six
-from astropy import modeling
-from astropy.modeling.core import _CompoundModel
-from astropy.modeling.models import Mapping, Identity
+import six
 
 from ... import tagged
 from ... import yamlutil
@@ -41,11 +38,13 @@ _tag_to_method_mapping = {
 
 class CompoundType(TransformType):
     name = ['transform/' + x for x in _tag_to_method_mapping.keys()]
-    types = [_CompoundModel]
+    types = ['astropy.modeling.core._CompoundModel']
     handle_dynamic_subclasses = True
 
     @classmethod
     def from_tree_tagged(cls, node, ctx):
+        from astropy import modeling
+
         tag = node._tag[node._tag.rfind('/')+1:]
 
         oper = _tag_to_method_mapping[tag]
@@ -108,10 +107,12 @@ class CompoundType(TransformType):
 
 class RemapAxesType(TransformType):
     name = 'transform/remap_axes'
-    types = [Mapping]
+    types = ['astropy.modeling.models.Mapping']
 
     @classmethod
     def from_tree_transform(cls, node, ctx):
+        from astropy.modeling.models import Identity, Mapping
+
         mapping = node['mapping']
         n_inputs = node.get('n_inputs')
         if all([isinstance(x, six.integer_types) for x in mapping]):

--- a/pyasdf/tags/transform/polynomial.py
+++ b/pyasdf/tags/transform/polynomial.py
@@ -6,8 +6,6 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from astropy import modeling
-
 from ... import yamlutil
 
 from .basic import TransformType
@@ -18,10 +16,12 @@ __all__ = ['ShiftType', 'ScaleType', 'PolynomialType']
 
 class ShiftType(TransformType):
     name = "transform/shift"
-    types = [modeling.models.Shift]
+    types = ['astropy.modeling.models.Shift']
 
     @classmethod
     def from_tree_transform(cls, node, ctx):
+        from astropy import modeling
+
         offset = node['offset']
         if not np.isscalar(offset):
             raise NotImplementedError(
@@ -36,6 +36,8 @@ class ShiftType(TransformType):
 
     @classmethod
     def assert_equal(cls, a, b):
+        from astropy import modeling
+
         # TODO: If models become comparable themselves, remove this.
         TransformType.assert_equal(a, b)
         assert (isinstance(a, modeling.models.Shift) and
@@ -45,10 +47,12 @@ class ShiftType(TransformType):
 
 class ScaleType(TransformType):
     name = "transform/scale"
-    types = [modeling.models.Scale]
+    types = ['astropy.modeling.models.Scale']
 
     @classmethod
     def from_tree_transform(cls, node, ctx):
+        from astropy import modeling
+
         factor = node['factor']
         if not np.isscalar(factor):
             raise NotImplementedError(
@@ -63,6 +67,8 @@ class ScaleType(TransformType):
 
     @classmethod
     def assert_equal(cls, a, b):
+        from astropy import modeling
+
         # TODO: If models become comparable themselves, remove this.
         TransformType.assert_equal(a, b)
         assert (isinstance(a, modeling.models.Scale) and
@@ -72,10 +78,13 @@ class ScaleType(TransformType):
 
 class PolynomialType(TransformType):
     name = "transform/polynomial"
-    types = [modeling.models.Polynomial1D, modeling.models.Polynomial2D]
+    types = ['astropy.modeling.models.Polynomial1D',
+             'astropy.modeling.models.Polynomial2D']
 
     @classmethod
     def from_tree_transform(cls, node, ctx):
+        from astropy import modeling
+
         coefficients = np.asarray(node['coefficients'])
         n_dim = coefficients.ndim
 
@@ -102,6 +111,8 @@ class PolynomialType(TransformType):
 
     @classmethod
     def to_tree_transform(cls, model, ctx):
+        from astropy import modeling
+
         if isinstance(model, modeling.models.Polynomial1D):
             coefficients = np.array(model.parameters)
         elif isinstance(model, modeling.models.Polynomial2D):
@@ -117,6 +128,8 @@ class PolynomialType(TransformType):
 
     @classmethod
     def assert_equal(cls, a, b):
+        from astropy import modeling
+
         # TODO: If models become comparable themselves, remove this.
         TransformType.assert_equal(a, b)
         assert (isinstance(a, (modeling.models.Polynomial1D, modeling.models.Polynomial2D)) and

--- a/pyasdf/tags/transform/projections.py
+++ b/pyasdf/tags/transform/projections.py
@@ -3,10 +3,7 @@
 
 from __future__ import absolute_import, division, unicode_literals, print_function
 
-import numpy as np
 from numpy.testing import assert_array_equal
-
-from astropy import modeling
 
 from ... import yamlutil
 
@@ -21,12 +18,14 @@ __all__ = ['AffineType', 'Rotate2DType', 'Rotate3DType', 'ZenithalPerspectiveTyp
 
 class AffineType(TransformType):
     name = "transform/affine"
-    types = [modeling.projections.AffineTransformation2D]
+    types = ['astropy.modeling.projections.AffineTransformation2D']
 
     @classmethod
     def from_tree_transform(cls, node, ctx):
+        from astropy import modeling
+
         matrix = node['matrix']
-        translation  = node['translation']
+        translation = node['translation']
         if matrix.shape != (2, 2):
             raise NotImplementedError(
                 "pyasdf currently only supports 2x2 (2D) rotation transformation "
@@ -54,10 +53,12 @@ class AffineType(TransformType):
 
 class Rotate2DType(TransformType):
     name = "transform/rotate2d"
-    types = [modeling.rotations.Rotation2D]
+    types = ['astropy.modeling.rotations.Rotation2D']
 
     @classmethod
     def from_tree_transform(cls, node, ctx):
+        from astropy import modeling
+
         return modeling.rotations.Rotation2D(node['angle'])
 
     @classmethod
@@ -66,6 +67,8 @@ class Rotate2DType(TransformType):
 
     @classmethod
     def assert_equal(cls, a, b):
+        from astropy import modeling
+
         # TODO: If models become comparable themselves, remove this.
         TransformType.assert_equal(a, b)
         assert (isinstance(a, modeling.rotations.Rotation2D) and
@@ -75,12 +78,14 @@ class Rotate2DType(TransformType):
 
 class Rotate3DType(TransformType):
     name = "transform/rotate3d"
-    types = [modeling.rotations.RotateNative2Celestial,
-             modeling.rotations.RotateCelestial2Native,
-             modeling.rotations.EulerAngleRotation]
+    types = ['astropy.modeling.rotations.RotateNative2Celestial',
+             'astropy.modeling.rotations.RotateCelestial2Native',
+             'astropy.modeling.rotations.EulerAngleRotation']
 
     @classmethod
     def from_tree_transform(cls, node, ctx):
+        from astropy import modeling
+
         if node['direction'] == 'native2celestial':
             return modeling.rotations.RotateNative2Celestial(node["phi"],
                                                              node["theta"],
@@ -98,6 +103,8 @@ class Rotate3DType(TransformType):
 
     @classmethod
     def to_tree_transform(cls, model, ctx):
+        from astropy import modeling
+
         if isinstance(model, modeling.rotations.RotateNative2Celestial):
             return {"phi": model.lon.value,
                     "theta": model.lat.value,
@@ -156,7 +163,8 @@ class ZenithalType(TransformType):
 
 class ZenithalPerspectiveType(ZenithalType):
     name = "transform/zenithal_perspective"
-    types = [modeling.projections.Pix2Sky_AZP, modeling.projections.Sky2Pix_AZP]
+    types = ['astropy.modeling.projections.Pix2Sky_AZP',
+             'astropy.modeling.projections.Sky2Pix_AZP']
 
     @classmethod
     def from_tree_transform(cls, node, ctx):
@@ -191,17 +199,20 @@ class ZenithalPerspectiveType(ZenithalType):
 
 class GnomonicType(ZenithalType):
     name = "transform/gnomonic"
-    types = [modeling.projections.Pix2Sky_TAN, modeling.projections.Sky2Pix_TAN]
+    types = ['astropy.modeling.projections.Pix2Sky_TAN',
+             'astropy.modeling.projections.Sky2Pix_TAN']
 
 
 class StereographicType(ZenithalType):
     name = "transform/stereographic"
-    types = [modeling.projections.Pix2Sky_STG, modeling.projections.Sky2Pix_STG]
+    types = ['astropy.modeling.projections.Pix2Sky_STG',
+             'astropy.modeling.projections.Sky2Pix_STG']
 
 
 class SlantOrthographicType(ZenithalType):
     name = "transform/slant_orthographic"
-    types = [modeling.projections.Pix2Sky_SIN, modeling.projections.Sky2Pix_SIN]
+    types = ['astropy.modeling.projections.Pix2Sky_SIN',
+             'astropy.modeling.projections.Sky2Pix_SIN']
 
 
 class CylindricalType(TransformType):
@@ -228,7 +239,8 @@ class CylindricalType(TransformType):
 
 class CylindricalPerspectiveType(CylindricalType):
     name = "transform/cylindrical_perspective"
-    types = [modeling.projections.Pix2Sky_CYP, modeling.projections.Sky2Pix_CYP]
+    types = ['astropy.modeling.projections.Pix2Sky_CYP',
+             'astropy.modeling.projections.Sky2Pix_CYP']
 
     @classmethod
     def from_tree_transform(cls, node, ctx):
@@ -263,7 +275,8 @@ class CylindricalPerspectiveType(CylindricalType):
 
 class CylindricalEqualAreaType(CylindricalType):
     name = "transform/cylindrical_equal_area"
-    types = [modeling.projections.Pix2Sky_CEA, modeling.projections.Sky2Pix_CEA]
+    types = ['astropy.modeling.projections.Pix2Sky_CEA',
+             'astropy.modeling.projections.Sky2Pix_CEA']
 
     @classmethod
     def from_tree_transform(cls, node, ctx):
@@ -294,9 +307,11 @@ class CylindricalEqualAreaType(CylindricalType):
 
 class PlateCarreeType(CylindricalType):
     name = "transforms/plate_carree"
-    types = [modeling.projections.Pix2Sky_CAR, modeling.projections.Sky2Pix_CAR]
+    types = ['astropy.modeling.projections.Pix2Sky_CAR',
+             'astropy.modeling.projections.Sky2Pix_CAR']
 
 
 class MercatorType(CylindricalType):
     name = "transforms/mercator"
-    types = [modeling.projections.Pix2Sky_MER, modeling.projections.Sky2Pix_MER]
+    types = ['astropy.modeling.projections.Pix2Sky_MER',
+             'astropy.modeling.projections.Sky2Pix_MER']

--- a/pyasdf/tags/transform/tests/test_transform.py
+++ b/pyasdf/tags/transform/tests/test_transform.py
@@ -3,19 +3,26 @@
 
 from __future__ import absolute_import, division, unicode_literals, print_function
 
-from astropy.modeling import models as astmodels
-from astropy.tests.helper import pytest
+try:
+    import astropy
+except ImportError:
+    HAS_ASTROPY = False
+    test_models = []
+else:
+    HAS_ASTROPY = True
+    from astropy.modeling import models as astmodels
 
+    test_models = [astmodels.Identity(2), astmodels.Polynomial1D(2, c0=1, c1=2, c2=3),
+                   astmodels.Polynomial2D(1, c0_0=1, c0_1=2, c1_0=3), astmodels.Shift(2.),
+                   astmodels.Scale(3.4), astmodels.RotateNative2Celestial(5.63, -72.5, 180),
+                   astmodels.RotateCelestial2Native(5.63, -72.5, 180),
+                   astmodels.EulerAngleRotation(23, 14, 2.3, axes_order='xzx')]
+
+import pytest
 from ....tests import helpers
 
 
-test_models = [astmodels.Identity(2), astmodels.Polynomial1D(2, c0=1, c1=2, c2=3),
-               astmodels.Polynomial2D(1, c0_0=1, c0_1=2, c1_0=3), astmodels.Shift(2.),
-               astmodels.Scale(3.4), astmodels.RotateNative2Celestial(5.63, -72.5, 180),
-               astmodels.RotateCelestial2Native(5.63, -72.5, 180),
-               astmodels.EulerAngleRotation(23, 14, 2.3, axes_order='xzx')]
-
-
+@pytest.mark.skipif('not HAS_ASTROPY')
 def test_transforms_compound(tmpdir):
     tree = {
         'compound':
@@ -29,6 +36,7 @@ def test_transforms_compound(tmpdir):
     helpers.assert_roundtrip_tree(tree, tmpdir)
 
 
+@pytest.mark.skipif('not HAS_ASTROPY')
 def test_inverse_transforms(tmpdir):
     rotation = astmodels.Rotation2D(32)
     rotation.inverse = astmodels.Rotation2D(45)
@@ -46,12 +54,14 @@ def test_inverse_transforms(tmpdir):
     helpers.assert_roundtrip_tree(tree, tmpdir, check)
 
 
+@pytest.mark.skipif('not HAS_ASTROPY')
 @pytest.mark.parametrize(('model'), test_models)
 def test_single_model(tmpdir, model):
     tree = {'single_model': model}
     helpers.assert_roundtrip_tree(tree, tmpdir)
 
 
+@pytest.mark.skipif('not HAS_ASTROPY')
 def test_name(tmpdir):
     def check(ff):
         assert ff.tree['rot'].name == 'foo'
@@ -60,6 +70,7 @@ def test_name(tmpdir):
     helpers.assert_roundtrip_tree(tree, tmpdir, check)
 
 
+@pytest.mark.skipif('not HAS_ASTROPY')
 def test_domain(tmpdir):
     def check(ff):
         assert ff.tree['rot'].meta['domain'] == {
@@ -72,6 +83,7 @@ def test_domain(tmpdir):
     helpers.assert_roundtrip_tree(tree, tmpdir, check)
 
 
+@pytest.mark.skipif('not HAS_ASTROPY')
 def test_zenithal_with_arguments(tmpdir):
     tree = {
         'azp': astmodels.Sky2Pix_AZP(0.5, 0.3)
@@ -80,6 +92,7 @@ def test_zenithal_with_arguments(tmpdir):
     helpers.assert_roundtrip_tree(tree, tmpdir)
 
 
+@pytest.mark.skipif('not HAS_ASTROPY')
 def test_naming_of_compound_model(tmpdir):
     """Issue #87"""
     def asdf_check(ff):

--- a/pyasdf/tags/unit/tests/test_unit.py
+++ b/pyasdf/tags/unit/tests/test_unit.py
@@ -5,7 +5,15 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 
 import io
 
-from astropy import units as u
+try:
+    import astropy
+except ImportError:
+    HAS_ASTROPY = False
+else:
+    HAS_ASTROPY = True
+    from astropy import units as u
+
+import pytest
 
 from .... import asdf
 from ....tests import helpers
@@ -14,6 +22,7 @@ from ....tests import helpers
 # TODO: Implement defunit
 
 
+@pytest.mark.skipif('not HAS_ASTROPY')
 def test_unit():
     yaml = """
 unit: !unit/unit "2.1798721  10-18kg m2 s-2"

--- a/pyasdf/tags/unit/unit.py
+++ b/pyasdf/tags/unit/unit.py
@@ -4,18 +4,20 @@
 from __future__ import absolute_import, division, unicode_literals, print_function
 
 
-from astropy.extern import six
-from astropy import units as u
+import six
 
 from ...asdftypes import AsdfType
 
 
 class UnitType(AsdfType):
     name = 'unit/unit'
-    types = [u.UnitBase]
+    types = ['astropy.units.UnitBase']
+    requires = ['astropy']
 
     @classmethod
     def to_tree(cls, node, ctx):
+        from astropy import units as u
+
         if isinstance(node, six.string_types):
             node = u.Unit(node, format='vounit', parse_strict='warn')
         if isinstance(node, u.UnitBase):
@@ -24,4 +26,6 @@ class UnitType(AsdfType):
 
     @classmethod
     def from_tree(cls, node, ctx):
+        from astropy import units as u
+
         return u.Unit(node, format='vounit', parse_strict='silent')

--- a/pyasdf/tests/data/missing.yaml
+++ b/pyasdf/tests/data/missing.yaml
@@ -1,0 +1,5 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://nowhere.org/schemas/custom/1.0.0/missing"
+type: object

--- a/pyasdf/tests/helpers.py
+++ b/pyasdf/tests/helpers.py
@@ -7,7 +7,7 @@ import io
 import os
 import sys
 
-from astropy.extern import six
+import six
 
 from ..asdf import AsdfFile, get_asdf_library_info
 from ..conftest import RangeHTTPServer

--- a/pyasdf/tests/setup_package.py
+++ b/pyasdf/tests/setup_package.py
@@ -6,4 +6,4 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 
 def get_package_data():  # pragma: no cover
     return {
-        str(_ASTROPY_PACKAGE_NAME_ + '.tests'): ['coveragerc', 'data/*.yaml']}
+        str(_PACKAGE_NAME_ + '.tests'): ['coveragerc', 'data/*.yaml']}

--- a/pyasdf/tests/test_compression.py
+++ b/pyasdf/tests/test_compression.py
@@ -8,7 +8,7 @@ import os
 
 import numpy as np
 
-from astropy.tests.helper import pytest
+import pytest
 
 from .. import asdf
 from .. import generic_io

--- a/pyasdf/tests/test_fits_embed.py
+++ b/pyasdf/tests/test_fits_embed.py
@@ -5,17 +5,26 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 
 import os
 
+try:
+    import astropy
+except ImportError:
+    HAS_ASTROPY = False
+else:
+    HAS_ASTROPY = True
+    from astropy.io import fits
+    from .. import fits_embed
+
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from astropy.io import fits
+import pytest
 
 from .. import asdf
-from .. import fits_embed
 
 from .helpers import assert_tree_match, close_fits
 
 
+@pytest.mark.skipif('not HAS_ASTROPY')
 def test_embed_asdf_in_fits_file(tmpdir):
     hdulist = fits.HDUList()
     hdulist.append(fits.ImageHDU(np.arange(512, dtype=np.float), name='SCI'))
@@ -58,6 +67,7 @@ def test_embed_asdf_in_fits_file(tmpdir):
         close_fits(hdulist2)
 
 
+@pytest.mark.skipif('not HAS_ASTROPY')
 def test_embed_asdf_in_fits_file_anonymous_extensions(tmpdir):
     hdulist = fits.HDUList()
     hdulist.append(fits.ImageHDU(np.arange(512, dtype=np.float)))
@@ -104,6 +114,7 @@ def test_embed_asdf_in_fits_file_anonymous_extensions(tmpdir):
         close_fits(hdulist2)
 
 
+@pytest.mark.skipif('not HAS_ASTROPY')
 def test_create_in_tree_first(tmpdir):
     tree = {
         'model': {

--- a/pyasdf/tests/test_generic_io.py
+++ b/pyasdf/tests/test_generic_io.py
@@ -7,9 +7,10 @@ import io
 import os
 import sys
 
-from astropy.extern import six
-import astropy.extern.six.moves.urllib.request as urllib_request
-from astropy.tests.helper import pytest, remote_data
+import pytest
+
+import six
+import six.moves.urllib.request as urllib_request
 
 import numpy as np
 

--- a/pyasdf/tests/test_low_level.py
+++ b/pyasdf/tests/test_low_level.py
@@ -6,11 +6,12 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 import io
 import os
 
-from astropy.extern import six
-from astropy.tests.helper import pytest
-
 import numpy as np
 from numpy.testing import assert_array_equal
+
+import pytest
+
+import six
 
 from .. import asdf
 from .. import block

--- a/pyasdf/tests/test_reference.py
+++ b/pyasdf/tests/test_reference.py
@@ -9,7 +9,7 @@ import os
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from astropy.tests.helper import pytest
+import pytest
 
 from .. import asdf
 from .. import reference

--- a/pyasdf/tests/test_schema.py
+++ b/pyasdf/tests/test_schema.py
@@ -6,13 +6,20 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 import io
 import os
 
-import numpy as np
-
-from astropy.extern import six
-from astropy.tests.helper import pytest
-from astropy import units as u
+try:
+    import astropy
+except ImportError:
+    HAS_ASTROPY = False
+else:
+    HAS_ASTROPY = True
 
 from jsonschema import ValidationError
+
+import numpy as np
+
+import pytest
+
+import six
 
 import yaml
 
@@ -60,6 +67,7 @@ def test_violate_toplevel_schema():
         ff.write_to(buff)
 
 
+@pytest.mark.skipif('not HAS_ASTROPY')
 def test_tagging_scalars():
     yaml = """
 unit: !unit/unit
@@ -67,6 +75,7 @@ unit: !unit/unit
 not_unit:
   m
     """
+    from astropy import units as u
 
     buff = helpers.yaml_to_asdf(yaml)
     with asdf.AsdfFile.open(buff) as ff:
@@ -395,3 +404,32 @@ def test_large_literals():
     with pytest.raises(ValidationError):
         ff.write_to(buff)
         print(buff.getvalue())
+
+
+@pytest.mark.skipif('not HAS_ASTROPY')
+def test_type_missing_dependencies():
+    from astropy.tests.helper import catch_warnings
+
+    class MissingType(asdftypes.AsdfType):
+        name = 'missing'
+        organization = 'nowhere.org'
+        version = (1, 0, 0)
+        standard = 'custom'
+        types = ['asdfghjkl12345.foo']
+        requires = ["ASDFGHJKL12345"]
+
+    class DefaultTypeExtension(CustomExtension):
+        @property
+        def types(self):
+            return [MissingType]
+
+    yaml = """
+custom: !<tag:nowhere.org:custom/1.0.0/missing>
+  b: {foo: 42}
+    """
+    buff = helpers.yaml_to_asdf(yaml)
+    with catch_warnings() as w:
+        with asdf.AsdfFile.open(buff, extensions=[DefaultTypeExtension()]) as ff:
+            assert ff.tree['custom']['b']['foo'] == 42
+
+    assert len(w) == 1

--- a/pyasdf/tests/test_stream.py
+++ b/pyasdf/tests/test_stream.py
@@ -6,10 +6,10 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 import io
 import os
 
-from astropy.tests.helper import pytest
-
 import numpy as np
 from numpy.testing import assert_array_equal
+
+import pytest
 
 from .. import asdf
 from .. import generic_io

--- a/pyasdf/tests/test_suite.py
+++ b/pyasdf/tests/test_suite.py
@@ -10,7 +10,7 @@ from .. import open
 
 from .helpers import assert_tree_match
 
-from astropy.tests.helper import pytest
+import pytest
 
 
 def test_reference_files():

--- a/pyasdf/tests/test_yaml.py
+++ b/pyasdf/tests/test_yaml.py
@@ -5,16 +5,23 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 
 import io
 
+try:
+    import astropy
+except ImportError:
+    HAS_ASTROPY = False
+else:
+    HAS_ASTROPY = True
+
 import numpy as np
 
-from astropy.extern import six
-from astropy import units as u
-from astropy.utils.compat.odict import OrderedDict
-from astropy.tests.helper import pytest
+import pytest
+
+import six
 
 import yaml
 
 from .. import asdf
+from ..compat.odict import OrderedDict
 from .. import tagged
 from .. import treeutil
 
@@ -121,6 +128,7 @@ def test_tags_removed_after_load(tmpdir):
     helpers.assert_roundtrip_tree(tree, tmpdir, check_asdf)
 
 
+@pytest.mark.skipif('not HAS_ASTROPY')
 def test_explicit_tags():
 
     yaml = """#ASDF 0.1.0
@@ -129,6 +137,8 @@ def test_explicit_tags():
 unit: !<tag:stsci.edu:asdf/0.1.0/unit/unit> m
 ...
     """
+    from astropy import units as u
+
     # Check that fully-qualified explicit tags work
 
     buff = helpers.yaml_to_asdf(yaml, yaml_headers=False)

--- a/pyasdf/treeutil.py
+++ b/pyasdf/treeutil.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 
 import inspect
 
-from astropy.extern import six
+import six
 
 from .tagged import tag_object
 

--- a/pyasdf/util.py
+++ b/pyasdf/util.py
@@ -4,15 +4,16 @@
 
 from __future__ import absolute_import, division, unicode_literals, print_function
 
-import itertools
+import inspect
 import math
 import struct
+import types
 
-from astropy.extern import six
-from astropy.extern.six.moves.urllib.parse import urljoin
-from astropy.extern.six.moves.urllib.request import pathname2url
-from astropy.extern.six.moves.urllib import parse as urlparse
-from astropy.extern.six.moves import zip as izip
+import six
+from six.moves.urllib.parse import urljoin
+from six.moves.urllib.request import pathname2url
+from six.moves.urllib import parse as urlparse
+from six.moves import zip as izip
 
 import numpy as np
 
@@ -207,3 +208,173 @@ class HashableDict(dict):
     """
     def __hash__(self):
         return hash(frozenset(self.items()))
+
+
+def resolve_name(name):
+    """Resolve a name like ``module.object`` to an object and return it.
+
+    This ends up working like ``from module import object`` but is easier
+    to deal with than the `__import__` builtin and supports digging into
+    submodules.
+
+    Parameters
+    ----------
+
+    name : `str`
+        A dotted path to a Python object--that is, the name of a function,
+        class, or other object in a module with the full path to that module,
+        including parent modules, separated by dots.  Also known as the fully
+        qualified name of the object.
+
+    Examples
+    --------
+
+    >>> resolve_name('pyasdf.util.resolve_name')
+    <function resolve_name at 0x...>
+
+    Raises
+    ------
+    `ImportError`
+        If the module or named object is not found.
+    """
+
+    # Note: On python 2 these must be str objects and not unicode
+    parts = [str(part) for part in name.split('.')]
+
+    if len(parts) == 1:
+        # No dots in the name--just a straight up module import
+        cursor = 1
+        attr_name = str('')  # Must not be unicode on Python 2
+    else:
+        cursor = len(parts) - 1
+        attr_name = parts[-1]
+
+    module_name = parts[:cursor]
+
+    while cursor > 0:
+        try:
+            ret = __import__(str('.'.join(module_name)), fromlist=[attr_name])
+            break
+        except ImportError:
+            if cursor == 0:
+                raise
+            cursor -= 1
+            module_name = parts[:cursor]
+            attr_name = parts[cursor]
+            ret = ''
+
+    for part in parts[cursor:]:
+        try:
+            ret = getattr(ret, part)
+        except AttributeError:
+            raise ImportError(name)
+
+    return ret
+
+
+def minversion(module, version, inclusive=True, version_path='__version__'):
+    """
+    Returns `True` if the specified Python module satisfies a minimum version
+    requirement, and `False` if not.
+
+    By default this uses `pkg_resources.parse_version` to do the version
+    comparison if available.  Otherwise it falls back on
+    `distutils.version.LooseVersion`.
+
+    Parameters
+    ----------
+
+    module : module or `str`
+        An imported module of which to check the version, or the name of
+        that module (in which case an import of that module is attempted--
+        if this fails `False` is returned).
+
+    version : `str`
+        The version as a string that this module must have at a minimum (e.g.
+        ``'0.12'``).
+
+    inclusive : `bool`
+        The specified version meets the requirement inclusively (i.e. ``>=``)
+        as opposed to strictly greater than (default: `True`).
+
+    version_path : `str`
+        A dotted attribute path to follow in the module for the version.
+        Defaults to just ``'__version__'``, which should work for most Python
+        modules.
+    """
+
+    if isinstance(module, types.ModuleType):
+        module_name = module.__name__
+    elif isinstance(module, six.string_types):
+        module_name = module
+        try:
+            module = resolve_name(module_name)
+        except ImportError:
+            return False
+    else:
+        raise ValueError('module argument must be an actual imported '
+                         'module, or the import name of the module; '
+                         'got {0!r}'.format(module))
+
+    if '.' not in version_path:
+        have_version = getattr(module, version_path)
+    else:
+        have_version = resolve_name('.'.join([module.__name__, version_path]))
+
+    try:
+        from pkg_resources import parse_version
+    except ImportError:
+        from distutils.version import LooseVersion as parse_version
+
+    if inclusive:
+        return parse_version(have_version) >= parse_version(version)
+    else:
+        return parse_version(have_version) > parse_version(version)
+
+
+class InheritDocstrings(type):
+    """
+    This metaclass makes methods of a class automatically have their
+    docstrings filled in from the methods they override in the base
+    class.
+
+    If the class uses multiple inheritance, the docstring will be
+    chosen from the first class in the bases list, in the same way as
+    methods are normally resolved in Python.  If this results in
+    selecting the wrong docstring, the docstring will need to be
+    explicitly included on the method.
+
+    For example::
+
+        >>> from pyasdf.util import InheritDocstrings
+        >>> import six
+        >>> @six.add_metaclass(InheritDocstrings)
+        ... class A(object):
+        ...     def wiggle(self):
+        ...         "Wiggle the thingamajig"
+        ...         pass
+        >>> class B(A):
+        ...     def wiggle(self):
+        ...         pass
+        >>> B.wiggle.__doc__
+        u'Wiggle the thingamajig'
+    """
+
+    def __init__(cls, name, bases, dct):
+        def is_public_member(key):
+            return (
+                (key.startswith('__') and key.endswith('__')
+                 and len(key) > 4) or
+                not key.startswith('_'))
+
+        for key, val in six.iteritems(dct):
+            if (inspect.isfunction(val) and
+                is_public_member(key) and
+                val.__doc__ is None):
+                for base in cls.__mro__[1:]:
+                    super_method = getattr(base, key, None)
+                    if super_method is not None:
+                        val.__doc__ = super_method.__doc__
+                        break
+
+        super(InheritDocstrings, cls).__init__(name, bases, dct)

--- a/pyasdf/versioning.py
+++ b/pyasdf/versioning.py
@@ -8,7 +8,7 @@ of the ASDF spec.
 
 from __future__ import absolute_import, division, unicode_literals, print_function
 
-from astropy.extern import six
+import six
 
 from . import util
 

--- a/pyasdf/yamlutil.py
+++ b/pyasdf/yamlutil.py
@@ -3,13 +3,13 @@
 
 from __future__ import absolute_import, division, unicode_literals, print_function
 
-from astropy.extern import six
-from astropy.utils.compat.odict import OrderedDict
-
 import numpy as np
+
+import six
 
 import yaml
 
+from . compat.odict import OrderedDict
 from . constants import YAML_TAG_PREFIX
 from . import schema
 from . import tagged

--- a/setup.py
+++ b/setup.py
@@ -13,12 +13,17 @@ if sys.version_info[0] >= 3:
     import builtins
 else:
     import __builtin__ as builtins
-builtins._ASTROPY_SETUP_ = True
+builtins._PYASDF_SETUP_ = True
 
 from astropy_helpers.setup_helpers import (
     register_commands, adjust_compiler, get_debug_option, get_package_info)
 from astropy_helpers.git_helpers import get_git_devstr
 from astropy_helpers.version_helpers import generate_version_py
+
+from astropy_helpers import test_helpers
+def _null_validate(self):
+    pass
+test_helpers.AstropyTest._validate_required_deps = _null_validate
 
 # Get some values from the setup.cfg
 from distutils import config
@@ -27,11 +32,11 @@ conf.read(['setup.cfg'])
 metadata = dict(conf.items('metadata'))
 
 PACKAGENAME = metadata.get('package_name', 'packagename')
-DESCRIPTION = metadata.get('description', 'Astropy affiliated package')
+DESCRIPTION = metadata.get('description', 'package description')
 AUTHOR = metadata.get('author', '')
 AUTHOR_EMAIL = metadata.get('author_email', '')
 LICENSE = metadata.get('license', 'unknown')
-URL = metadata.get('url', 'http://astropy.org')
+URL = metadata.get('url', '')
 
 # Get the long description from the package's docstring
 __import__(PACKAGENAME)
@@ -40,7 +45,7 @@ LONG_DESCRIPTION = package.__doc__
 
 # Store the package name in a built-in variable so it's easy
 # to get from other parts of the setup infrastructure
-builtins._ASTROPY_PACKAGE_NAME_ = PACKAGENAME
+builtins._PACKAGE_NAME_ = PACKAGENAME
 
 # VERSION should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
 VERSION = '0.0.dev'
@@ -120,9 +125,11 @@ setup(name=PACKAGENAME,
       description=DESCRIPTION,
       scripts=scripts,
       install_requires=[
-          'astropy>=1.0',
           'pyyaml>=3.10',
-          'jsonschema>=2.3.0'],
+          'jsonschema>=2.3.0',
+          'six>=1.9.0',
+          'pytest>=2.7.2'
+      ],
       author=AUTHOR,
       author_email=AUTHOR_EMAIL,
       license=LICENSE,


### PR DESCRIPTION
This is a reduced version of #160 which removes the dependency on astropy for everything but running the tests.  I know that seems kind of odd, but these changes form the basis of something that needs to be done in the near term -- to make a wrapper around `gwcs` (which will also be an optional dependency).

