### PR TITLE
fix problems with remap_axes

### DIFF
--- a/pyasdf/tags/transform/compound.py
+++ b/pyasdf/tags/transform/compound.py
@@ -116,7 +116,7 @@ class RemapAxesType(TransformType):
         mapping = node['mapping']
         n_inputs = node.get('n_inputs')
         if all([isinstance(x, six.integer_types) for x in mapping]):
-            return Mapping(mapping, n_inputs)
+            return Mapping(tuple(mapping), n_inputs)
 
         if n_inputs is None:
             n_inputs = max([x for x in mapping
@@ -137,9 +137,13 @@ class RemapAxesType(TransformType):
 
     @classmethod
     def to_tree_transform(cls, model, ctx):
-        return {'mapping': model.mapping}
+        node = {'mapping': list(model.mapping)}
+        if model.n_inputs > max(model.mapping) + 1:
+            node['n_inputs'] = model.n_inputs
+        return node
 
     @classmethod
     def assert_equal(cls, a, b):
         TransformType.assert_equal(a, b)
         assert a.mapping == b.mapping
+        assert(a.n_inputs == b.n_inputs)

--- a/pyasdf/tags/transform/tests/test_transform.py
+++ b/pyasdf/tags/transform/tests/test_transform.py
@@ -16,7 +16,8 @@ else:
                    astmodels.Polynomial2D(1, c0_0=1, c0_1=2, c1_0=3), astmodels.Shift(2.),
                    astmodels.Scale(3.4), astmodels.RotateNative2Celestial(5.63, -72.5, 180),
                    astmodels.RotateCelestial2Native(5.63, -72.5, 180),
-                   astmodels.EulerAngleRotation(23, 14, 2.3, axes_order='xzx')]
+                   astmodels.EulerAngleRotation(23, 14, 2.3, axes_order='xzx'),
+                   astmodels.Mapping((0, 1), n_inputs=3)]
 
 import pytest
 


### PR DESCRIPTION
This fixes two problems:

- In the case of dropping an axis, e.g. `models.Mapping((0, 1), n_inputs=3),  the original model was not restored because `n_inputs` was not written out to file.
- `mapping` of type tuple was not accepted.