### PR TITLE
Rename generated Validator class as ASDFValidator

### DIFF
--- a/pyasdf/schema.py
+++ b/pyasdf/schema.py
@@ -252,7 +252,7 @@ def _create_validator(validators=YAML_VALIDATORS):
                 for x in super(ASDFValidator, self).iter_errors(instance, _schema=schema):
                     yield x
 
-    return validator
+    return ASDFValidator
 
 
 # We want to load mappings in schema as ordered dicts


### PR DESCRIPTION
I found it super confusing in debugging that the Validator looks to be coming from jsonschema, when in fact it's being created in asdf.schema, and the iter_errors method being overwritten.

This should make the situation a little less confusing.  I was also thinking of adding a custom metaclass to the validator with a more informative `__repr__` telling us exactly what metaschema this validator is for, as well as displaying the `validators` mapping.