### PR TITLE
Validate Python tuples as `type: array` under YAML Schema

### DIFF
--- a/pyasdf/schema.py
+++ b/pyasdf/schema.py
@@ -210,7 +210,7 @@ def _create_validator(validators=YAML_VALIDATORS):
                                   validators=validators)
 
     class ASDFValidator(base_cls):
-        DEFAULT_TYPES = base_cls.DEFAULT_TYPES
+        DEFAULT_TYPES = base_cls.DEFAULT_TYPES.copy()
         DEFAULT_TYPES['array'] = (list, tuple)
 
         def iter_errors(self, instance, _schema=None, _seen=set()):

--- a/pyasdf/schema.py
+++ b/pyasdf/schema.py
@@ -252,7 +252,7 @@ def _create_validator(validators=YAML_VALIDATORS):
                 for x in super(ASDFValidator, self).iter_errors(instance, _schema=schema):
                     yield x
 
-    return validator
+    return ASDFValidator
 
 
 # We want to load mappings in schema as ordered dicts

--- a/pyasdf/schema.py
+++ b/pyasdf/schema.py
@@ -206,9 +206,13 @@ REMOVE_DEFAULTS['properties'] = validate_remove_default
 def _create_validator(validators=YAML_VALIDATORS):
     meta_schema = load_schema(YAML_SCHEMA_METASCHEMA_ID,
                               mresolver.default_url_mapping)
+    base_cls = mvalidators.create(meta_schema=meta_schema,
+                                  validators=validators)
 
-    class ASDFValidator(mvalidators.create(meta_schema=meta_schema,
-                                           validators=validators)):
+    class ASDFValidator(base_cls):
+        DEFAULT_TYPES = base_cls.DEFAULT_TYPES
+        DEFAULT_TYPES['array'] = (list, tuple)
+
         def iter_errors(self, instance, _schema=None, _seen=set()):
             # We can't validate anything that looks like an external reference,
             # since we don't have the actual content, so we just have to defer


### PR DESCRIPTION
Per the discussion [here](https://github.com/spacetelescope/gwcs/pull/19/files#r37652995), pyyaml will already write out tuples using the YAML sequence type.  However, jsonschema does *not* accept tuples for `type: array`.  In fairness a tuple really isn't like a JavaScript array, but for purposes of *output* validation I feel like it should pass muster (it will never be read back in as a tuple, which is fine).

This PR is built on top of #170, but could just as easily be cleaved apart from it.

Still needs tests.