### PR TITLE
Prevent dumper from splitting new lines.

### DIFF
--- a/pyasdf/yamlutil.py
+++ b/pyasdf/yamlutil.py
@@ -308,4 +308,4 @@ def dump_tree(tree, fd, ctx):
         explicit_start=True, explicit_end=True,
         version=yaml_version,
         allow_unicode=True, encoding='utf-8',
-        tags=tags)
+        tags=tags, width=10000)


### PR DESCRIPTION
This prevents `yaml.SafeDumper` from splitting long lines into multiple lines which in turn causes the pyasdf parser to error in such cases and when the delimiter is a `\n`. This showed up in the context of JWST data models. Here's a minimal example of the problem:

```
from jwst_lib import models
from pyasdf import generic_io, yamlutil
m = models.ImageModel() # meta is not populated
sub={'name': 'FULL', 'xstart': 1, 'ystart': 1, 'xsize': 2014, 'ysize':1023, 'slowaxis': -1, 'fastaxis': 2}
m.meta.subarray = sub
fd = generic_io.get_file('mm', mode='w')
yamlutil.dump_tree(m._instance, fd, m._asdf)
fd.close()
```
Reading the file shows how yaml split the long line.
```
f=open('mm')
f.read()
subarray: {fastaxis: 2, name: FULL, slowaxis: -1, xsize: 2014, xstart: 1, ysize: 1023,\n    ystart: 1}
```

This fixes the immediate problem but is there a better fix. 
@embray @bernie-simon 