### PR TITLE
Should be '--init' not 'init'

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ install:
     - "powershell ci-helpers/appveyor/install-miniconda.ps1"
     - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
     - "activate test"
-    - "git submodule init asdf-standard"
+    - "git submodule update --init asdf-standard"
 
 # Not a .NET project
 build: false


### PR DESCRIPTION
Just fixes a typo that should get the appveyor builds going again on top of #180 