### PR TITLE
stop support for python 2.6 as astropy does not support it any more

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ addons:
     - dvipng
 
 python:
-  - 2.6
   - 2.7
   - 3.3
   - 3.4


### PR DESCRIPTION
Remove support for python 2.6 .