### PR TITLE
fix classifiers so that pypi accepts the package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,14 +9,14 @@ url = http://github.com/spacetelescope/asdf
 edit_on_github = False
 github_project = spacetelescope/asdf
 classifiers =
-    'Programming Language :: Python'
-    'Programming Language :: Python :: 3'
-    'Programming Language :: Python :: 3.3'
-    'Programming Language :: Python :: 3.4'
-    'Programming Language :: Python :: 3.5'
-    'Programming Language :: Python :: 3.6'
-    'Programming Language :: Python :: 3.7'
-    'Development Status :: 5 - Production/Stable'
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.3
+    Programming Language :: Python :: 3.4
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Development Status :: 5 - Production/Stable
 
 [options]
 python_requires= >=3.3


### PR DESCRIPTION
Uploading to PyPi of 2.4.0 failed with an error
```
Invalid value for classifiers. Error: ''Programming Language :: Python'' is not a valid choice for this field
```
This fixes the classifiers (works on testpypi now).