### PR TITLE
Add _tagged_tree_transform argument to asdf.open

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ The ASDF Standard is at v1.6.0
 - Discard cache of lazy-loaded block data when it is no longer referenced
   by the tree. [#1280]
 
-- Add ``tree_mapper`` argument to ``asdf.open`` to permit arbitrary
+- Add ``_tagged_tree_transform`` argument to ``asdf.open`` to permit arbitrary
   transformations of the tagged tree prior to conversion.  [#1289]
 
 2.14.3 (2022-12-15)

--- a/asdf/asdf.py
+++ b/asdf/asdf.py
@@ -810,7 +810,7 @@ class AsdfFile:
         _force_raw_types=False,
         strict_extension_check=False,
         ignore_missing_extensions=False,
-        tree_mapper=None,
+        _tagged_tree_transform=None,
         **kwargs,
     ):
         """Attempt to populate AsdfFile data from file-like object"""
@@ -882,8 +882,8 @@ class AsdfFile:
                 self._blocks.read_internal_blocks(fd, past_magic=True, validate_checksums=validate_checksums)
                 self._blocks.read_block_index(fd, self)
 
-            if tree_mapper is not None:
-                tree = tree_mapper(tree)
+            if _tagged_tree_transform is not None:
+                tree = _tagged_tree_transform(tree)
 
             tree = reference.find_references(tree, self)
 
@@ -920,7 +920,7 @@ class AsdfFile:
         _force_raw_types=False,
         strict_extension_check=False,
         ignore_missing_extensions=False,
-        tree_mapper=None,
+        _tagged_tree_transform=None,
         **kwargs,
     ):
         """Attempt to open file-like object as either AsdfFile or AsdfInFits"""
@@ -937,7 +937,7 @@ class AsdfFile:
                 _force_raw_types,
                 strict_extension_check,
                 ignore_missing_extensions,
-                tree_mapper=tree_mapper,
+                _tagged_tree_transform=_tagged_tree_transform,
                 **kwargs,
             )
         except Exception as e:
@@ -957,7 +957,7 @@ class AsdfFile:
         _force_raw_types=False,
         strict_extension_check=False,
         ignore_missing_extensions=False,
-        tree_mapper=None,
+        _tagged_tree_transform=None,
         **kwargs,
     ):
         """Attempt to open a generic_file instance as either AsdfFile or AsdfInFits"""
@@ -1004,7 +1004,7 @@ class AsdfFile:
                 _force_raw_types=_force_raw_types,
                 strict_extension_check=strict_extension_check,
                 ignore_missing_extensions=ignore_missing_extensions,
-                tree_mapper=tree_mapper,
+                _tagged_tree_transform=_tagged_tree_transform,
                 **kwargs,
             )
 
@@ -1776,7 +1776,7 @@ def open_asdf(
     strict_extension_check=False,
     ignore_missing_extensions=False,
     _compat=False,
-    tree_mapper=None,
+    _tagged_tree_transform=None,
     **kwargs,
 ):
     """
@@ -1851,9 +1851,10 @@ def open_asdf(
         and custom schemas.  Recommended unless the file is already known
         to be valid.
 
-    tree_mapper : callable, optional
+    _tagged_tree_transform : callable, optional
         Callable that accepts the tagged ASDF tree before conversion
-        and returns a modified tree.
+        and returns a modified tree.  This argument is provisional and
+        may change in future versions of asdf.
 
     Returns
     -------
@@ -1884,7 +1885,7 @@ def open_asdf(
         _force_raw_types=_force_raw_types,
         strict_extension_check=strict_extension_check,
         ignore_missing_extensions=ignore_missing_extensions,
-        tree_mapper=tree_mapper,
+        _tagged_tree_transform=_tagged_tree_transform,
         **kwargs,
     )
 

--- a/asdf/tests/test_api.py
+++ b/asdf/tests/test_api.py
@@ -524,15 +524,15 @@ def test_none_values(tmp_path):
         assert af["foo"] is None
 
 
-def test_tree_mapper(tmp_path):
+def test_tagged_tree_transform(tmp_path):
     path = str(tmp_path / "test.asdf")
 
     af = asdf.AsdfFile({"foo": "bar"})
     af.write_to(path)
 
-    def tree_mapper(tree):
+    def callback(tree):
         tree["foo"] = "baz"
         return tree
 
-    with asdf.open(path, tree_mapper=tree_mapper) as af:
+    with asdf.open(path, _tagged_tree_transform=callback) as af:
         assert af["foo"] == "baz"


### PR DESCRIPTION
This adds a `_tagged_tree_transform` argument to `asdf.open` that permits arbitrary transformations of the tagged tree before it is converted.  We'll need this in order to move ASDF-in-FITS support to stdatamodels.