### PR TITLE
add astrocut to downstream ci

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -55,6 +55,7 @@ jobs:
       # Any env name which does not start with `pyXY` will use this Python version.
       default_python: '3.10'
       envs: |
+        - linux: astrocut
         - linux: gwcs
         - linux: jwst
         - linux: stdatamodels

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ env_list =
     coverage
     py{39,310,311,312}{,-compatibility,-coverage,-jsonschema}{,-devdeps}{,-parallel}
     asdf{-standard,-transform-schemas,-unit-schemas,-wcs-schemas,-coordinates-schemas,-astropy,-zarr,-compression}
+    astrocut
     gwcs
     jwst
     stdatamodels
@@ -187,6 +188,21 @@ commands_pre =
     pip freeze
 commands =
     pytest specutils
+
+[testenv:astrocut]
+change_dir = {env_tmp_dir}
+allowlist_externals =
+    git
+    bash
+extras =
+commands_pre =
+    bash -c "pip freeze -q | grep 'asdf @' > {env_tmp_dir}/requirements.txt"
+    git clone https://github.com/spacetelescope/astrocut.git
+    pip install -e astrocut[test]
+    pip install -r {env_tmp_dir}/requirements.txt
+    pip freeze
+commands =
+    pytest astrocut
 
 [testenv:gwcs]
 change_dir = {env_tmp_dir}


### PR DESCRIPTION
# Description

astrocut added asdf support in: https://github.com/spacetelescope/astrocut/pull/105

This PR adds astrocut tests to the downstream CI.

# Checklist:

- [ ] pre-commit checks ran successfully
- [ ] tests ran successfully
- [ ] for a public change, a changelog entry was added
- [ ] for a public change, documentation was updated
- [ ] for any new features, unit tests were added
