### PR TITLE
remove test check for tag in fits schema

### DIFF
--- a/asdf/_tests/test_schema.py
+++ b/asdf/_tests/test_schema.py
@@ -842,8 +842,8 @@ def test_schema_resolved_via_entry_points():
     extension_manager = asdf.extension.get_cached_extension_manager(get_config().extensions)
     schema_uris = extension_manager.get_tag_definition(tag).schema_uris
     assert len(schema_uris) > 0
-    s = schema.load_schema(schema_uris[0], resolve_references=True)
-    assert tag in repr(s)
+    s = schema.load_schema(schema_uris[0])
+    assert s["id"] == schema_uris[0]
 
 
 @pytest.mark.parametrize("num", [constants.MAX_NUMBER + 1, constants.MIN_NUMBER - 1])


### PR DESCRIPTION
# Description

Update `test_schema_resolved_via_entry_points` to not check for a `tag` entry in the `fits` schema. The `tag` is not required and this test is preventing it's removal in:

https://github.com/asdf-format/asdf-standard/pull/421

# Checklist:

- [ ] pre-commit checks ran successfully
- [ ] tests ran successfully
- [ ] for a public change, a changelog entry was added
- [ ] for a public change, documentation was updated
- [ ] for any new features, unit tests were added
