### PR TITLE
return dict_keys instead of KeysView for AsdfFile.keys

### DIFF
--- a/asdf/_asdf.py
+++ b/asdf/_asdf.py
@@ -557,6 +557,9 @@ class AsdfFile:
         self._tree = AsdfObject(tree)
 
     def keys(self):
+        """
+        Return view of top-level keys in the tree.
+        """
         return self.tree.keys()
 
     def __getitem__(self, key):

--- a/asdf/tags/core/__init__.py
+++ b/asdf/tags/core/__init__.py
@@ -1,4 +1,5 @@
 import collections
+import functools
 
 from .constant import Constant
 from .external_reference import ExternalArrayReference
@@ -24,7 +25,9 @@ __all__ = [
 # to pass an isinstance(..., dict) check and to allow it to be "lazy"
 # loaded when "lazy_tree=True".
 class AsdfObject(collections.UserDict, dict):
-    pass
+    @functools.wraps(collections.UserDict.keys)
+    def keys(self):
+        return self.data.keys()
 
 
 class Software(dict):


### PR DESCRIPTION
## Description

Work-in-progress. Need to investigate if `values` or other methods also would benefit from overrides.


xref: https://github.com/spacetelescope/roman_datamodels/pull/524

## Tasks

- [ ] [run `pre-commit` on your machine](https://pre-commit.com/#quick-start)
- [ ] run `pytest` on your machine
- [ ] Does this PR add new features and / or change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
    - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
    - [ ] update relevant docstrings and / or `docs/` page
    - [ ] for any new features, add unit tests

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: bug fix
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
