### PR TITLE
add AsdfFile.blocks API

### DIFF
--- a/asdf/_asdf.py
+++ b/asdf/_asdf.py
@@ -15,8 +15,8 @@ from . import _node_info as node_info
 from . import _version as version
 from . import constants, generic_io, lazy_nodes, reference, schema, treeutil, util, versioning, yamlutil
 from ._block.manager import Manager as BlockManager
-from ._block.viewer import BlockViewer
 from ._helpers import validate_version
+from .blocks import BlockViewer
 from .config import config_context, get_config
 from .exceptions import (
     AsdfManifestURIMismatchWarning,
@@ -141,7 +141,7 @@ class AsdfFile:
         self._closed = False
         self._external_asdf_by_uri = {}
         self._blocks = BlockManager(uri=uri, lazy_load=lazy_load, memmap=memmap)
-        self.blocks = BlockViewer(self._blocks)
+        self._blocks_view = BlockViewer(self._blocks)
         if tree is None:
             # Bypassing the tree property here, to avoid validating
             # an empty tree.
@@ -546,8 +546,6 @@ class AsdfFile:
     def tree(self):
         """
         Get/set the tree of data in the ASDF file.
-
-        When set, the tree will be validated against the ASDF schema.
         """
         if self._closed:
             msg = "Cannot access data from closed ASDF file"
@@ -557,6 +555,13 @@ class AsdfFile:
     @tree.setter
     def tree(self, tree):
         self._tree = AsdfObject(tree)
+
+    @property
+    def blocks(self):
+        """
+        A `asdf.blocks.BlockViewer` with read-only access to ASDF blocks loaded from the ASDF file.
+        """
+        return self._blocks_view
 
     def keys(self):
         return self.tree.keys()

--- a/asdf/_block/viewer.py
+++ b/asdf/_block/viewer.py
@@ -1,0 +1,81 @@
+import math
+import sys
+from collections.abc import Sequence
+from types import MappingProxyType
+
+from asdf.constants import BLOCK_FLAG_STREAMED
+
+
+class BlockView:
+    def __init__(self, read_block):
+        self._read_block = read_block
+
+    @property
+    def header(self):
+        return MappingProxyType(self._read_block.header)
+
+    @property
+    def offset(self):
+        return self._read_block.offset
+
+    @property
+    def data_offset(self):
+        return self._read_block.data_offset
+
+    @property
+    def loaded(self):
+        return self._read_block._cached_data is not None
+
+    def load(self, out=None):
+        if out is not None:
+            raise NotImplementedError("Reading into an array is not yet supported")
+        return self._read_block.cached_data
+
+    def _info(self):
+        header = self.header
+        if header["flags"] & BLOCK_FLAG_STREAMED:
+            return "Stream"
+        line = f"{header['allocated_size']} bytes"
+        if header["allocated_size"] != header["used_size"]:
+            line += f", {header['used_size']} used"
+        if header["compression"] != b"\0\0\0\0":
+            line += f", {header['compression'].decode('ascii')} compression"
+        return line
+
+
+class BlockViewer(Sequence):
+    def __init__(self, manager):
+        self._manager = manager
+
+    def __len__(self):
+        return len(self._manager.blocks)
+
+    def __getitem__(self, index):
+        return BlockView(self._manager.blocks[index])
+
+    def _info(self):
+        n = len(self)
+        if not n:
+            return []
+
+        # conditionally use tty bold formatting:w
+        if hasattr(sys.stdout, "isatty") and sys.stdout.isatty():
+
+            def bold(s):
+                return f"\x1b[1m{s}\x1b[0m"
+
+        else:
+
+            def bold(s):
+                return s
+
+        index_string_length = int(math.log10(n)) + 1
+        lines = []
+        for i, block in enumerate(self):
+            index_string = str(i).rjust(index_string_length)
+            prefix = bold(f"█ Block {index_string}")
+            lines.append(f"{prefix}: {block._info()}")
+        return lines
+
+    def info(self):
+        print("\n".join(self._info()))

--- a/asdf/_commands/info.py
+++ b/asdf/_commands/info.py
@@ -6,7 +6,7 @@ import asdf
 
 from .main import Command
 
-__all__ = ["info"]
+__all__ = []
 
 
 class Info(Command):
@@ -29,6 +29,9 @@ class Info(Command):
         parser.add_argument(
             "--max-cols", type=int, help="Maximum length of line. If not provided lines will have no length limit."
         )
+        parser.add_argument(
+            "--hide-blocks", action="store_true", default=False, help="Skip printing information about the ASDF blocks"
+        )
 
         parser.add_argument(
             "--show-values",
@@ -45,9 +48,8 @@ class Info(Command):
 
     @classmethod
     def run(cls, args):
-        info(args.filename, args.max_rows, args.max_cols, args.show_values)
+        info(args.filename, args.max_rows, args.max_cols, args.show_values, args.hide_blocks)
 
 
-def info(filename, max_rows, max_cols, show_values):
-    with asdf.open(filename) as af:
-        af.info(max_rows, max_cols, show_values)
+def info(filename, max_rows, max_cols, show_values, hide_blocks):
+    asdf.info(filename, max_rows=max_rows, max_cols=max_cols, show_values=show_values, show_blocks=not hide_blocks)

--- a/asdf/_convenience.py
+++ b/asdf/_convenience.py
@@ -12,7 +12,13 @@ from ._display import DEFAULT_MAX_COLS, DEFAULT_MAX_ROWS, DEFAULT_SHOW_VALUES
 __all__ = ["info"]
 
 
-def info(node_or_path, max_rows=DEFAULT_MAX_ROWS, max_cols=DEFAULT_MAX_COLS, show_values=DEFAULT_SHOW_VALUES):
+def info(
+    node_or_path,
+    max_rows=DEFAULT_MAX_ROWS,
+    max_cols=DEFAULT_MAX_COLS,
+    show_values=DEFAULT_SHOW_VALUES,
+    show_blocks=True,
+):
     """
     Print a rendering of an ASDF tree or sub-tree to stdout.
 
@@ -39,9 +45,14 @@ def info(node_or_path, max_rows=DEFAULT_MAX_ROWS, max_cols=DEFAULT_MAX_COLS, sho
     show_values : bool, optional
         Set to False to disable display of primitive values in
         the rendered tree.
+
+    show_blocks : bool, optional
+        Display block information after the tree. If max_rows
+        does not allow displaying the block information it will
+        not be shown.
     """
     with _manage_node(node_or_path) as node:
-        node.info(max_rows=max_rows, max_cols=max_cols, show_values=show_values)
+        node.info(max_rows=max_rows, max_cols=max_cols, show_values=show_values, show_blocks=show_blocks)
 
 
 @contextmanager

--- a/asdf/_tests/_block/test_viewer.py
+++ b/asdf/_tests/_block/test_viewer.py
@@ -78,8 +78,11 @@ def test_loaded(tmp_path):
 def test_info(asdf_file, capsys):
     asdf_file.blocks.info()
     lines = capsys.readouterr().out.splitlines()
-    assert "Block 0: 8192 bytes, 336 used" in lines[0]
-    assert "Block 1: 8192 bytes, 878 used, bzp2 compression" in lines[1]
+    # use private API to confirm public
+    h = asdf_file._blocks.blocks[0].header
+    assert f"Block 0: {h['allocated_size']} bytes, {h['used_size']} used" in lines[0]
+    h = asdf_file._blocks.blocks[1].header
+    assert f"Block 1: {h['allocated_size']} bytes, {h['used_size']} used, bzp2 compression" in lines[1]
     assert "Block 2: Stream" in lines[2]
 
 

--- a/asdf/_tests/_block/test_viewer.py
+++ b/asdf/_tests/_block/test_viewer.py
@@ -1,0 +1,109 @@
+import numpy as np
+import pytest
+
+import asdf
+from asdf.constants import BLOCK_MAGIC
+
+
+@pytest.fixture()
+def asdf_file(tmp_path):
+    fn = tmp_path / "test.asdf"
+    tree = {
+        "array_0": np.arange(42),
+        "array_1": np.arange(720, dtype="f8"),
+    }
+    tree["view_0"] = tree["array_0"]
+    tree["view_1"] = tree["array_1"][:42]
+    tree["stream"] = asdf.Stream([1], "f4")
+    af = asdf.AsdfFile(tree)
+    af.set_array_compression(tree["array_1"], "bzp2")
+    af.write_to(fn, pad_blocks=0.1)
+    with asdf.open(fn) as af:
+        yield af
+
+
+def test_count_blocks(asdf_file):
+    assert len(asdf_file.blocks) == 3
+
+
+def test_flags(asdf_file):
+    assert asdf_file.blocks[0].header["flags"] == 0
+    assert asdf_file.blocks[1].header["flags"] == 0
+    assert asdf_file.blocks[2].header["flags"] == 1
+
+
+def test_compression(asdf_file):
+    assert asdf_file.blocks[0].header["compression"] == b"\x00\x00\x00\x00"
+    assert asdf_file.blocks[1].header["compression"] == b"bzp2"
+    assert asdf_file.blocks[2].header["compression"] == b"\x00\x00\x00\x00"
+
+
+def test_header_read_only(asdf_file):
+    with pytest.raises(TypeError, match="does not support item assignment"):
+        asdf_file.blocks[0].header["flags"] = 42
+
+
+@pytest.mark.parametrize("attr", ("offset", "data_offset", "loaded"))
+def test_attr_read_only(asdf_file, attr):
+    with pytest.raises(AttributeError, match="can't set attribute"):
+        setattr(asdf_file.blocks[0], attr, 42)
+
+
+def test_offset(asdf_file):
+    # test a relative offset to make this test not depend on a specific tree size.
+    relative_offset = asdf_file.blocks[1].offset - asdf_file.blocks[0].data_offset
+    assert asdf_file.blocks[0].header["allocated_size"] + len(BLOCK_MAGIC) == relative_offset
+
+
+def test_loaded(tmp_path):
+    # can't use the asdf_file fixture here as the Stream
+    # causes all blocks to be loaded
+    fn = tmp_path / "test.asdf"
+    asdf.dump({"arrays": [np.zeros(3) for _ in range(3)]}, fn)
+
+    with asdf.open(fn) as af:
+        assert not af.blocks[0].loaded
+        assert not af.blocks[1].loaded
+        assert not af.blocks[2].loaded
+
+        # trigger loading of all blocks
+        assert np.sum([a.sum() for a in af["arrays"]]) == 0
+
+        assert af.blocks[0].loaded
+        assert af.blocks[1].loaded
+        assert af.blocks[2].loaded
+
+
+def test_info(asdf_file, capsys):
+    asdf_file.blocks.info()
+    lines = capsys.readouterr().out.splitlines()
+    assert "Block 0: 8192 bytes, 336 used" in lines[0]
+    assert "Block 1: 8192 bytes, 878 used, bzp2 compression" in lines[1]
+    assert "Block 2: Stream" in lines[2]
+
+
+@pytest.mark.parametrize("show_blocks", (True, False))
+@pytest.mark.parametrize(
+    "max_rows, blocks_expected",
+    (
+        (None, True),
+        (10, False),
+        ((None, 10), True),
+        ((10, None), False),
+    ),
+)
+def test_info_limited(asdf_file, capsys, max_rows, blocks_expected, show_blocks):
+    asdf_file.info(max_rows=max_rows, show_blocks=show_blocks)
+    out = capsys.readouterr().out
+    if blocks_expected and show_blocks:
+        assert "Block 0" in out
+    else:
+        assert "Block 0" not in out
+
+
+def test_info_many_blocks(tmp_path, capsys):
+    fn = tmp_path / "test.asdf"
+    asdf.dump({"arrays": [np.zeros(3) for _ in range(11)]}, fn)
+    asdf.info(fn, max_rows=None)
+    out = capsys.readouterr().out
+    assert "Block  0" in out

--- a/asdf/_tests/_block/test_viewer.py
+++ b/asdf/_tests/_block/test_viewer.py
@@ -45,7 +45,8 @@ def test_header_read_only(asdf_file):
 
 @pytest.mark.parametrize("attr", ("offset", "data_offset", "loaded"))
 def test_attr_read_only(asdf_file, attr):
-    with pytest.raises(AttributeError, match="can't set attribute"):
+    # message varies by python version
+    with pytest.raises(AttributeError, match="(can't set attribute|object has no setter)"):
         setattr(asdf_file.blocks[0], attr, 42)
 
 

--- a/asdf/_tests/commands/test_info.py
+++ b/asdf/_tests/commands/test_info.py
@@ -21,3 +21,18 @@ def test_info_command(capsys, test_data_path):
     assert "frames" in captured.out
     new_len = len(captured.out.split("\n"))
     assert new_len < original_len
+
+
+@pytest.mark.parametrize("hide_blocks", (True, False))
+def test_hide_blocks(capsys, test_data_path, hide_blocks):
+    file_path = test_data_path / "ndarray0.asdf"
+
+    args = ["info", str(file_path)]
+    if hide_blocks:
+        args.append("--hide-blocks")
+    assert main.main_from_args(args) == 0
+    captured = capsys.readouterr()
+    if hide_blocks:
+        assert "Block 0:" not in captured.out
+    else:
+        assert "Block 0:" in captured.out

--- a/asdf/blocks.py
+++ b/asdf/blocks.py
@@ -5,25 +5,43 @@ from types import MappingProxyType
 
 from asdf.constants import BLOCK_FLAG_STREAMED
 
+__all__ = ["BlockView", "BlockViewer"]
+
 
 class BlockView:
+    """
+    A read-only view of an ASDF block.
+    """
+
     def __init__(self, read_block):
         self._read_block = read_block
 
     @property
     def header(self):
+        """
+        MappingProxy: A read-only mapping of ASDF block header contents.
+        """
         return MappingProxyType(self._read_block.header)
 
     @property
     def offset(self):
+        """
+        int: The offset (in bytes) of the ASDF block from the start of the file.
+        """
         return self._read_block.offset
 
     @property
     def data_offset(self):
+        """
+        int: The offset (in bytes) of the ASDF block data from the start of the file.
+        """
         return self._read_block.data_offset
 
     @property
     def loaded(self):
+        """
+        bool: True if the ASDF block data has been loaded (and cached).
+        """
         return self._read_block._cached_data is not None
 
     def load(self, out=None):
@@ -44,6 +62,10 @@ class BlockView:
 
 
 class BlockViewer(Sequence):
+    """
+    A read-only sequence of `BlockView` objects.
+    """
+
     def __init__(self, manager):
         self._manager = manager
 
@@ -78,4 +100,7 @@ class BlockViewer(Sequence):
         return lines
 
     def info(self):
+        """
+        Print a rendering of these blocks to stdout.
+        """
         print("\n".join(self._info()))

--- a/docs/asdf/user_api/asdf_blocks.rst
+++ b/docs/asdf/user_api/asdf_blocks.rst
@@ -1,0 +1,8 @@
+******************
+asdf.blocks Module
+******************
+
+.. currentmodule:: asdf
+
+.. automodapi:: asdf.blocks
+    :no-inheritance-diagram:

--- a/docs/asdf/user_api/index.rst
+++ b/docs/asdf/user_api/index.rst
@@ -9,9 +9,11 @@ User API
     :hidden:
 
     asdf_package.rst
+    asdf_blocks.rst
     asdf_search.rst
     asdf_config.rst
 
 * :doc:`asdf Package <asdf_package>`
+* :doc:`asdf.blocks Module <asdf_blocks>`
 * :doc:`asdf.search Module <asdf_search>`
 * :doc:`asdf.config Module <asdf_config>`


### PR DESCRIPTION
## Description

Add `AsdfFile.blocks` to provide information about ASDF blocks when an AsdfFile is created from an ASDF file.

`blocks` is an immutable sequence of read-only views of the block data.
```python
>> af = asdf.open("foo.asdf")
>> af.info(max_rows=None)
root (AsdfObject)
├─asdf_library (Software)
│ ├─author (str): The ASDF Developers
│ ├─homepage (str): http://github.com/asdf-format/asdf
│ ├─name (str): asdf
│ └─version (str): 4.3.1.dev5+g2dc5555d.d20250722
├─history (dict)
│ └─extensions (list)
│   └─[0] (ExtensionMetadata)
│     ├─extension_class (str): asdf.extension._manifest.ManifestExtension
│     ├─extension_uri (str): asdf://asdf-format.org/core/extensions/core-1.6.0
│     ├─manifest_software (Software)
│     │ ├─name (str): asdf_standard
│     │ └─version (str): 1.1.1
│     └─software (Software)
│       ├─name (str): asdf
│       └─version (str): 4.3.1.dev5+g2dc5555d.d20250722
└─arrs (list)
  ├─[0] (NDArrayType)
  │ ├─shape (tuple)
  │ │ └─[0] (int): 3
  │ └─dtype (Float64DType): float64
  ├─[1] (NDArrayType)
  │ ├─shape (tuple)
  │ │ └─[0] (int): 3
  │ └─dtype (Float64DType): float64
  ├─[2] (NDArrayType)
  │ ├─shape (tuple)
  │ │ └─[0] (int): 3
  │ └─dtype (Float64DType): float64
  ├─[3] (NDArrayType)
  │ ├─shape (tuple)
  │ │ └─[0] (int): 3
  │ └─dtype (Float64DType): float64
  └─[4] (NDArrayType)
    ├─shape (tuple)
    │ └─[0] (int): 3
    └─dtype (Float64DType): float64
█ Block 0: 24 bytes
█ Block 1: 24 bytes
█ Block 2: 24 bytes
█ Block 3: 24 bytes
█ Block 4: 24 bytes
>> len(af.blocks)
5
>> af.blocks[0].header
mappingproxy({'flags': 0,
              'compression': b'\x00\x00\x00\x00',
              'allocated_size': 24,
              'used_size': 24,
              'data_size': 24,
              'checksum': b'\x16\x81\xff\xc6\xe0F\xc7\xaf\x98\xc9\xe6\xc22\xa3\xfe\n'})
>> af.blocks[0].offset
1070
>> af.blocks[0].data_offset
1120
>> af.blocks[0].loaded()
False
>> arr = af.blocks[0].load()
>> arr
array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
       0, 0], dtype=uint8)
>> af.blocks[0].loaded()
True
>> af.blocks[0].load() is arr  # returns the exact same array
True
>> af.blocks[0].load() is af['arrs'][0].base  # data is shared with the tree
True
```

TODO:
- [ ] load into array (and via `NDArrayType`)

## Tasks

- [ ] [run `pre-commit` on your machine](https://pre-commit.com/#quick-start)
- [ ] run `pytest` on your machine
- [ ] Does this PR add new features and / or change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
    - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
    - [ ] update relevant docstrings and / or `docs/` page
    - [ ] for any new features, add unit tests

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: bug fix
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
