### PR TITLE
TEST: resolve all refs

### DIFF
--- a/asdf/_tests/test_schema.py
+++ b/asdf/_tests/test_schema.py
@@ -132,7 +132,7 @@ required: [foobar]
     schema_path = tmp_path / "nugatory.yaml"
     schema_path.write_bytes(schema_def.encode())
 
-    schema_tree = schema.load_schema(str(schema_path), resolve_references=True)
+    schema_tree = schema.load_schema(str(schema_path))
     schema.check_schema(schema_tree)
 
 
@@ -156,7 +156,7 @@ required: [foobar]
     schema_path = tmp_path / "nugatory.yaml"
     schema_path.write_bytes(schema_def.encode())
 
-    schema_tree = schema.load_schema(str(schema_path), resolve_references=True)
+    schema_tree = schema.load_schema(str(schema_path))
     schema.check_schema(schema_tree)
 
 
@@ -812,6 +812,11 @@ def test_self_reference_resolution(test_data_path):
     )
     assert "$ref" not in repr(s)
     assert s["anyOf"][1] == s["anyOf"][0]
+
+
+def test_resolve_references():
+    s = schema.load_schema("http://stsci.edu/schemas/asdf/core/ndarray-1.0.0", resolve_references=True)
+    assert "$ref" not in repr(s)
 
 
 def test_schema_resolved_via_entry_points():

--- a/asdf/_tests/test_schema.py
+++ b/asdf/_tests/test_schema.py
@@ -132,7 +132,7 @@ required: [foobar]
     schema_path = tmp_path / "nugatory.yaml"
     schema_path.write_bytes(schema_def.encode())
 
-    schema_tree = schema.load_schema(str(schema_path))
+    schema_tree = schema.load_schema(str(schema_path), resolve_references=True)
     schema.check_schema(schema_tree)
 
 
@@ -156,7 +156,7 @@ required: [foobar]
     schema_path = tmp_path / "nugatory.yaml"
     schema_path.write_bytes(schema_def.encode())
 
-    schema_tree = schema.load_schema(str(schema_path))
+    schema_tree = schema.load_schema(str(schema_path), resolve_references=True)
     schema.check_schema(schema_tree)
 
 
@@ -815,7 +815,9 @@ def test_self_reference_resolution(test_data_path):
 
 
 def test_resolve_references():
-    s = schema.load_schema("http://stsci.edu/schemas/asdf/core/ndarray-1.0.0", resolve_references=True)
+    s = schema.load_schema(
+        "http://stsci.edu/schemas/asdf/core/ndarray-1.0.0", resolve_references=True, allow_recursion=True
+    )
     assert "$ref" not in repr(s)
 
 

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -442,15 +442,14 @@ def _load_schema_cached(url, resolve_references):
 
                 if suburl_base == url or suburl_base == schema.get("id"):
                     # This is a local ref, which we'll resolve in both cases.
-                    subschema = schema
+                    return reference.resolve_fragment(schema, suburl_fragment)
                 else:
                     subschema = load_schema(suburl_base, True)
-
-                return reference.resolve_fragment(subschema, suburl_fragment)
+                    return reference.resolve_fragment(subschema, suburl_fragment)
 
             return node
 
-        schema = treeutil.walk_and_modify(schema, resolve_refs)
+        schema = treeutil.walk_and_modify(schema, resolve_refs, in_place=True)
 
     return schema
 

--- a/asdf/schema.py
+++ b/asdf/schema.py
@@ -380,7 +380,7 @@ def _make_jsonschema_refresolver():
     )
 
 
-def load_schema(url, resolve_references=False):
+def load_schema(url, resolve_references=False, allow_recursion=False):
     """
     Load a schema from the given URL.
 
@@ -390,13 +390,18 @@ def load_schema(url, resolve_references=False):
         The path to the schema
 
     resolve_references : bool, optional
-        If ``True``, resolve all ``$ref`` references.
+        If ``True``, resolve ``$ref`` references. Note that local
+        references will only be resolved 1 level deep to prevent
+        returning recursive schemas (see allow_recursion).
 
+    allow_recursion : bool, options
+        If ``True``, resolve all local references possibly producing
+        a recursive schema.
     """
     # We want to cache the work that went into constructing the schema, but returning
     # the same object is treacherous, because users who mutate the result will not
     # expect that they're changing the schema everywhere.
-    return copy.deepcopy(_load_schema_cached(url, resolve_references))
+    return copy.deepcopy(_load_schema_cached(url, resolve_references, allow_recursion))
 
 
 def _safe_resolve(json_id, uri):
@@ -427,7 +432,7 @@ def _safe_resolve(json_id, uri):
 
 
 @lru_cache
-def _load_schema_cached(url, resolve_references):
+def _load_schema_cached(url, resolve_references, allow_recursion=False):
     loader = _make_schema_loader()
     schema, url = loader(url)
 
@@ -449,7 +454,7 @@ def _load_schema_cached(url, resolve_references):
 
             return node
 
-        schema = treeutil.walk_and_modify(schema, resolve_refs, in_place=True)
+        schema = treeutil.walk_and_modify(schema, resolve_refs, in_place=allow_recursion)
 
     return schema
 


### PR DESCRIPTION
Resolve all refs for `load_schema(..., resolve_refs=True)`. This can create a recursive schema (which is fine for validation but will fail check_schema and result in infinite walks for itertree, walk, etc). I suspect we will want to make this an "opt-in" behavior since I think this is a breaking change. If we want to change the defaults it'll have to wait until asdf 6.0.

Lots of downstream failures from essentially:
- pytest-asdf-plugin using [resolve_refs](https://github.com/asdf-format/pytest-asdf-plugin/blob/69196cc97615857b9f5af04a4b8404cdcf5d33c0/src/pytest_asdf_plugin/plugin.py#L136) (which I don't think is needed)
- any schema referencing ndarray (or a similar recursive schema) now is a recursive dict
- pytest-asdf-plugin passes this recursive dict to `check_schema` (which fails since that's not supported)

Making the behavior opt-in and/or updating pytest-asdf-plugin should those failures.

Closes: https://github.com/asdf-format/asdf/issues/1727

## Description

<!--
Please describe what this PR accomplishes.
If the changes are non-obvious, please explain how they work.
If this PR adds a new feature please include tests and documentation.
If this PR fixes an issue, please add closing keywords (eg 'fixes #XXX')
-->

## Tasks

- [ ] [run `pre-commit` on your machine](https://pre-commit.com/#quick-start)
- [ ] run `pytest` on your machine
- [ ] Does this PR add new features and / or change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
    - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
    - [ ] update relevant docstrings and / or `docs/` page
    - [ ] for any new features, add unit tests

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: bug fix
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
