### PR TITLE
fix test failing on dev pytest

### DIFF
--- a/asdf/_tests/test_custom_schema.py
+++ b/asdf/_tests/test_custom_schema.py
@@ -60,27 +60,27 @@ def schema_name(request, test_data_path, as_pathlib):
 
 
 @pytest.mark.parametrize(
-    "schema_name, tree, expected_error",
+    "schema_name, test_tree, expected_error",
     TEST_CASES,
     indirect=["schema_name"],
 )
-def test_custom_validation_write_to(tmp_path, schema_name, tree, expected_error):
+def test_custom_validation_write_to(tmp_path, schema_name, test_tree, expected_error):
     asdf_file = tmp_path / "out.asdf"
 
     ctx = pytest.raises(ValidationError, match=expected_error) if expected_error else nullcontext()
     with ctx:
-        asdf.AsdfFile(tree, custom_schema=schema_name).write_to(asdf_file)
+        asdf.AsdfFile(test_tree, custom_schema=schema_name).write_to(asdf_file)
 
 
 @pytest.mark.parametrize(
-    "schema_name, tree, expected_error",
+    "schema_name, test_tree, expected_error",
     TEST_CASES,
     indirect=["schema_name"],
 )
-def test_custom_validation_open(tmp_path, schema_name, tree, expected_error):
+def test_custom_validation_open(tmp_path, schema_name, test_tree, expected_error):
     asdf_file = tmp_path / "out.asdf"
 
-    asdf.AsdfFile(tree).write_to(asdf_file)
+    asdf.AsdfFile(test_tree).write_to(asdf_file)
     ctx = pytest.raises(ValidationError, match=expected_error) if expected_error else nullcontext()
 
     with ctx, asdf.open(asdf_file, custom_schema=schema_name):
@@ -88,39 +88,39 @@ def test_custom_validation_open(tmp_path, schema_name, tree, expected_error):
 
 
 @pytest.mark.parametrize(
-    "schema_name, tree, expected_error",
+    "schema_name, test_tree, expected_error",
     TEST_CASES,
     indirect=["schema_name"],
 )
-def test_custom_validation_validate(schema_name, tree, expected_error):
+def test_custom_validation_validate(schema_name, test_tree, expected_error):
 
     ctx = pytest.raises(ValidationError, match=expected_error) if expected_error else nullcontext()
 
     with ctx:
-        asdf.AsdfFile(tree, custom_schema=schema_name).validate()
+        asdf.AsdfFile(test_tree, custom_schema=schema_name).validate()
 
 
 @pytest.mark.parametrize(
-    "schema_name, tree, expected_error",
+    "schema_name, test_tree, expected_error",
     TEST_CASES,
     indirect=["schema_name"],
 )
-def test_custom_validation_dumps(schema_name, tree, expected_error):
+def test_custom_validation_dumps(schema_name, test_tree, expected_error):
 
     ctx = pytest.raises(ValidationError, match=expected_error) if expected_error else nullcontext()
 
     with ctx:
-        asdf.dumps(tree, custom_schema=schema_name)
+        asdf.dumps(test_tree, custom_schema=schema_name)
 
 
 @pytest.mark.parametrize(
-    "schema_name, tree, expected_error",
+    "schema_name, test_tree, expected_error",
     TEST_CASES,
     indirect=["schema_name"],
 )
-def test_custom_validation_loads(schema_name, tree, expected_error):
+def test_custom_validation_loads(schema_name, test_tree, expected_error):
 
-    contents = asdf.dumps(tree)
+    contents = asdf.dumps(test_tree)
 
     ctx = pytest.raises(ValidationError, match=expected_error) if expected_error else nullcontext()
 
@@ -129,28 +129,28 @@ def test_custom_validation_loads(schema_name, tree, expected_error):
 
 
 @pytest.mark.parametrize(
-    "schema_name, tree, expected_error",
+    "schema_name, test_tree, expected_error",
     TEST_CASES,
     indirect=["schema_name"],
 )
-def test_custom_validation_dump(tmp_path, schema_name, tree, expected_error):
+def test_custom_validation_dump(tmp_path, schema_name, test_tree, expected_error):
     asdf_file = tmp_path / "out.asdf"
 
     ctx = pytest.raises(ValidationError, match=expected_error) if expected_error else nullcontext()
 
     with ctx:
-        asdf.dump(tree, asdf_file, custom_schema=schema_name)
+        asdf.dump(test_tree, asdf_file, custom_schema=schema_name)
 
 
 @pytest.mark.parametrize(
-    "schema_name, tree, expected_error",
+    "schema_name, test_tree, expected_error",
     TEST_CASES,
     indirect=["schema_name"],
 )
-def test_custom_validation_load(tmp_path, schema_name, tree, expected_error):
+def test_custom_validation_load(tmp_path, schema_name, test_tree, expected_error):
     asdf_file = tmp_path / "out.asdf"
 
-    asdf.AsdfFile(tree).write_to(asdf_file)
+    asdf.AsdfFile(test_tree).write_to(asdf_file)
     ctx = pytest.raises(ValidationError, match=expected_error) if expected_error else nullcontext()
 
     with ctx:


### PR DESCRIPTION
## Description

A few tests are failing with pytest-dev:
https://github.com/asdf-format/asdf/actions/runs/19420723535/job/55557560788#step:10:98
I opened an upstream issue:
https://github.com/pytest-dev/pytest/issues/13974
but in case this is not a bug but instead expected behavior where  the `tree` arguments here:
https://github.com/asdf-format/asdf/blob/740c807b212d505f7e8a8756b22c541d25a1e448/asdf/_tests/test_custom_schema.py#L62-L67
do not match the `tree` fixture:
https://github.com/asdf-format/asdf/blob/740c807b212d505f7e8a8756b22c541d25a1e448/asdf/_tests/conftest.py#L49
this PR can work around the change.

## Tasks

- [ ] [run `pre-commit` on your machine](https://pre-commit.com/#quick-start)
- [ ] run `pytest` on your machine
- [ ] Does this PR add new features and / or change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
    - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
    - [ ] update relevant docstrings and / or `docs/` page
    - [ ] for any new features, add unit tests

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: bug fix
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
