### PR TITLE
update changelog for 5.2.0 release

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,28 @@
+5.2.0 (2026-03-19)
+==================
+
+Bugfix
+------
+
+- Fix bug in validation where a failure within a schema combiner can result in
+  failure to correctly validate a tree. (`#1999
+  <https://github.com/asdf-format/asdf/pull/1999>`_)
+
+
+General
+-------
+
+- Remove unused dependency asdf-transform-schemas. (`#1965
+  <https://github.com/asdf-format/asdf/pull/1965>`_)
+
+
+Removal
+-------
+
+- Drop support for python 3.9. (`#1992
+  <https://github.com/asdf-format/asdf/pull/1992>`_)
+
+
 5.1.0 (2025-11-06)
 ==================
 

--- a/changes/1965.general.rst
+++ b/changes/1965.general.rst
@@ -1,1 +1,0 @@
-Remove unused dependency asdf-transform-schemas.

--- a/changes/1992.removal.rst
+++ b/changes/1992.removal.rst
@@ -1,1 +1,0 @@
-Drop support for python 3.9.

--- a/changes/1999.bugfix.rst
+++ b/changes/1999.bugfix.rst
@@ -1,1 +1,0 @@
-Fix bug in validation where a failure within a schema combiner can result in failure to correctly validate a tree.


### PR DESCRIPTION
Update changelog for 5.2.0 release

Roman: https://github.com/spacetelescope/RegressionTests/actions/runs/23300330216
jwst: https://github.com/spacetelescope/RegressionTests/actions/runs/23300355641