### PR TITLE
only validate the new entry in add_history_entry

### DIFF
--- a/asdf/_asdf.py
+++ b/asdf/_asdf.py
@@ -1095,6 +1095,12 @@ class AsdfFile:
         if software is not None:
             entry["software"] = software
 
+        # validate the history entry
+        schema.validate(
+            yamlutil.custom_tree_to_tagged_tree({"entry": entry}, self),
+            ctx=self,
+        )
+
         if self.version >= versioning.NEW_HISTORY_FORMAT_MIN_VERSION:
             if "history" not in self.tree:
                 self.tree["history"] = {"entries": []}
@@ -1102,23 +1108,11 @@ class AsdfFile:
                 self.tree["history"]["entries"] = []
 
             self.tree["history"]["entries"].append(entry)
-
-            try:
-                self.validate()
-            except Exception:
-                self.tree["history"]["entries"].pop()
-                raise
         else:
             if "history" not in self.tree:
                 self.tree["history"] = []
 
             self.tree["history"].append(entry)
-
-            try:
-                self.validate()
-            except Exception:
-                self.tree["history"].pop()
-                raise
 
     def get_history_entries(self):
         """

--- a/asdf/_tests/test_history.py
+++ b/asdf/_tests/test_history.py
@@ -273,3 +273,23 @@ def test_metadata_with_custom_extension(tmp_path):
 
         with asdf.open(file_path_3) as af:
             assert len(af["history"]["extensions"]) == 2
+
+
+def test_history_validate():
+    """
+    Test that add_history_entry validates the generated entry and doesn't
+    add the entry to the history list if invalid.
+    """
+    af = asdf.AsdfFile()
+    # add an invalid item to the tree to check if adding a history entry validates
+    # the entire tree
+    af["invalid"] = asdf.tagged.TaggedDict({}, tag="tag:stsci.edu:asdf/core/ndarray-1.1.0")
+    with pytest.raises(ValidationError):
+        af.validate()
+
+    af.add_history_entry("test")
+    assert af.get_history_entries()[0]["description"] == "test"
+
+    with pytest.raises(ValidationError):
+        af.add_history_entry(1)
+    assert len(af.get_history_entries()) == 1

--- a/asdf/_tests/test_history.py
+++ b/asdf/_tests/test_history.py
@@ -280,7 +280,7 @@ def test_history_validate():
     Test that add_history_entry validates the generated entry and doesn't
     add the entry to the history list if invalid.
     """
-    af = asdf.AsdfFile()
+    af = asdf.AsdfFile(version="1.6.0")
     # add an invalid item to the tree to check if adding a history entry validates
     # the entire tree
     af["invalid"] = asdf.tagged.TaggedDict({}, tag="tag:stsci.edu:asdf/core/ndarray-1.1.0")

--- a/changes/2029.bugfix.rst
+++ b/changes/2029.bugfix.rst
@@ -1,0 +1,1 @@
+Remove whole-tree validation in ``AsdfFile.add_history_entry`` and replace it with validation of the newly created entry.


### PR DESCRIPTION
## Description

Closes #1736

Remove the whole-tree validation in `add_history_entry` and replace it with validation of the newly created `HistoryEntry`.

## Tasks

- [x] [run `pre-commit` on your machine](https://pre-commit.com/#quick-start)
- [x] run `pytest` on your machine
- [ ] Does this PR add new features and / or change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
    - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
    - [ ] update relevant docstrings and / or `docs/` page
    - [ ] for any new features, add unit tests

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: bug fix
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
