### PR TITLE
Add `typing-extensions` dependency

### DIFF
--- a/asdf/typing.py
+++ b/asdf/typing.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any, AnyStr, Literal, Protocol, TypeAlias
+from typing import Any, Literal, Protocol, TypeAlias
 
 import numpy.typing as npt
+from typing_extensions import Reader, Writer
 
 from asdf.generic_io import GenericFile
 from asdf.versioning import AsdfVersion
@@ -34,20 +35,6 @@ class ExtensionLike(Protocol):
 
     @property
     def extension_uri(self) -> str | None: ...
-
-
-# These protocols are backports of types that were added to the standard library in 3.14.
-# Whenever we drop support for Python <3.14 we can replace these with the standard library equivalents.
-class Reader(Protocol[AnyStr]):  # pyrefly: ignore[variance-mismatch]
-    """Object with a ``read`` method that returns string or bytes."""
-
-    def read(self, /) -> AnyStr: ...
-
-
-class Writer(Protocol[AnyStr]):  # pyrefly: ignore[variance-mismatch]
-    """Object with a ``write`` method that accepts string or bytes."""
-
-    def write(self, data: AnyStr, /) -> None: ...
 
 
 # Ideally this would be `str | int | bool`

--- a/changes/2040.general.rst
+++ b/changes/2040.general.rst
@@ -1,0 +1,1 @@
+Added ``typing-extensions`` as a package dependency.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
   "packaging>=19",
   "pyyaml>=6.0",
   "semantic_version>=2.8",
+  "typing-extensions>=4.14",
 
   # for vendorized jsonschema
   "attrs>=22.2.0",


### PR DESCRIPTION
## Description
* Added `typing-extensions` as a dependency
* Removed custom `Reader` and `Writer` protocols in `asdf.typing` and replaced them with the backports from `typing_extensions`

`typing-extensions` backports various typing features so that they're available in older Python versions. 
In addition to letting us remove the custom protocols as described above, it also gives access to the `deprecated` decorator which was added to `warnings` in Python 3.14 and will be very useful as we start to deprecate parts of the API.

Worth noting that `typing-extensions` is already an indirect dependency of several optional dependencies.