### PR TITLE
Replace `pre-commit` with `prek`

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,13 +4,13 @@ Thanks for contributing to asdf!
 Your PR should trigger the CI (after approval for first-time contributors)
 which will:
 
-- check your code for 'style' using pre-commit
+- check your code for 'style' using prek
 - run your PR against the asdf unit tests for various OSes, python versions, and dependency versions
 - perform a test build of your PR
 
 It is highly recommended that you run some of these tests locally by:
 
-- [installing pre-commit](https://pre-commit.com/#quick-start)
+- [installing prek](https://prek.j178.dev/quickstart/)
 - [running pytest](https://docs.pytest.org/en/7.1.x/getting-started.html)
 
 This will increase the chances your PR will pass the required CI tests.
@@ -27,7 +27,7 @@ If this PR fixes an issue, please add closing keywords (eg 'fixes #XXX')
 
 ## Tasks
 
-- [ ] [run `pre-commit` on your machine](https://pre-commit.com/#quick-start)
+- [ ] [run `prek` on your machine](https://prek.j178.dev/quickstart/)
 - [ ] run `pytest` on your machine
 - [ ] Does this PR add new features and / or change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
     - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - uses: actions/setup-python@v6
-    - uses: pre-commit/action@v3.0.1
+    - uses: j178/prek-action@v2
   type-checking:
     runs-on: ubuntu-latest
     steps:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -42,11 +42,9 @@ to the maintainers, who are glad to assist you.
     you run these tools regularly on your code to ensure that it is formatted
     correctly.
 
-    To make this easier, we have included `pre-commit <https://pre-commit.com/>`__
-    support for ASDF. We suggest that you install ``pre-commit``, so that your
-    code is automatically formatted before you commit. For those who do not run
-    these tools regularly, the ``pre-commit-ci`` bot will attempt to fix the issues
-    with your pull request when you submit it.
+    To make this easier, we have included `prek <https://prek.j178.dev/>`__
+    support for ASDF. We suggest that you install ``prek`` (or ``precommit``) so that your
+    code is automatically formatted before you commit.
 
 .. note::
     Backporting changes is done automatically using ``meeseeksdev``. If you are


### PR DESCRIPTION
## Description
* Replaced pre-commit Github action with [j178/prek-action](https://github.com/j178/prek-action)
* Updated contributor docs to suggest prek instead of pre-commit

Closes #2034 

I kept the name of the CI job as `pre-commit` to avoid breaking branch protections and such, plus I think the name is still fairly accurate.

There's also a "pre-commit enabled" badge on the readme. Not sure if we wanted to leave it as-is, update it, or remove it.

Let me know if you think this needs a changelog entry.