### PR TITLE
Replace `black` and `blacken-docs` with `ruff`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,20 +43,11 @@ repos:
       exclude: "asdf/(extern||_jsonschema)/.*"
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: 'v0.13.0'
+  rev: 'v0.15.12'
   hooks:
-    - id: ruff
+    - id: ruff-check
       args: ["--fix"]
-
-- repo: https://github.com/psf/black
-  rev: 25.1.0
-  hooks:
-    - id: black
-
-- repo: https://github.com/asottile/blacken-docs
-  rev: '1.20.0'
-  hooks:
-    - id: blacken-docs
+    - id: ruff-format
 
 - repo: https://github.com/tombi-toml/tombi-pre-commit
   rev: v0.9.25

--- a/asdf/_display.py
+++ b/asdf/_display.py
@@ -40,7 +40,7 @@ def render_table(
     inner_width = key_width + val_width + 1
 
     # Format each row with key left-aligned and value centered
-    content = [f"┃ {key:<{key_width-2}} │ {value:^{val_width-2}} ┃" for key, value in rows]
+    content = [f"┃ {key:<{key_width - 2}} │ {value:^{val_width - 2}} ┃" for key, value in rows]
     return [
         "┏" + "━" * inner_width + "┓",
         f"┃{title:^{inner_width}s}┃",  # Centered table title

--- a/asdf/_tests/test_info.py
+++ b/asdf/_tests/test_info.py
@@ -786,9 +786,7 @@ properties:
         properties:
             bar:
                 title: bar_title
-""".encode(
-        "ascii"
-    )
+""".encode("ascii")
 
     class MyExtension:
         extension_uri = "asdf://somewhere.org/extensions/foo-1.0.0"

--- a/asdf/_tests/test_reference.py
+++ b/asdf/_tests/test_reference.py
@@ -174,7 +174,9 @@ def test_make_reference(tmp_path):
 
         ff.write_to(os.path.join(str(tmp_path), "source.asdf"))
 
-    with (asdf.open(os.path.join(str(tmp_path), "source.asdf")) as ff,):
+    with (
+        asdf.open(os.path.join(str(tmp_path), "source.asdf")) as ff,
+    ):
         ff.find_references()
         assert ff.tree["ref"]._uri == "external.asdf#f~0o~0o~1/a"
 

--- a/asdf/tags/core/external_reference.py
+++ b/asdf/tags/core/external_reference.py
@@ -30,7 +30,7 @@ class ExternalArrayReference:
 
     >>> import asdf
     >>> ref = asdf.ExternalArrayReference("myfitsfile.fits", 1, "float64", (100, 100))
-    >>> tree = {'reference': ref}
+    >>> tree = {"reference": ref}
     >>> with asdf.AsdfFile(tree) as ff:
     ...     ff.write_to("test.asdf")
 

--- a/asdf/tags/core/integer.py
+++ b/asdf/tags/core/integer.py
@@ -33,9 +33,9 @@ class IntegerType:
     >>> # Store the large integer value to the tree using asdf.IntegerType
     >>> tree = dict(largeval=asdf.IntegerType(largeval))
     >>> with asdf.AsdfFile(tree) as af:
-    ...     af.write_to('largeval.asdf')
-    >>> with asdf.open('largeval.asdf') as aa:
-    ...     assert aa['largeval'] == largeval
+    ...     af.write_to("largeval.asdf")
+    >>> with asdf.open("largeval.asdf") as aa:
+    ...     assert aa["largeval"] == largeval
     """
 
     def __init__(self, value, storage_type="internal"):

--- a/integration_tests/compatibility/test_file_compatibility.py
+++ b/integration_tests/compatibility/test_file_compatibility.py
@@ -199,7 +199,10 @@ def test_file_compatibility(asdf_version, env_path, tmp_path):
                 str(standard_version),
                 capture_output=True,
             ), f"asdf library version {asdf_version} failed to generate an ASDF Standard {standard_version} file"
-            assert_file_correct(old_file_path), (
-                f"asdf library version {asdf_version} produced an ASDF Standard {standard_version}"
-                "that this code failed to read"
+            (
+                assert_file_correct(old_file_path),
+                (
+                    f"asdf library version {asdf_version} produced an ASDF Standard {standard_version}"
+                    "that this code failed to read"
+                ),
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,6 +160,10 @@ target-version = "py310"
 line-length = 120
 extend-exclude = ["asdf/_extern/*", "asdf/_jsonschema/*", "docs/*"]
 
+[tool.ruff.format]
+docstring-code-format = true
+docstring-code-line-length = 88
+
 [tool.ruff.lint]
 future-annotations = true
 select = [


### PR DESCRIPTION
## Description
* Replaced `black` and `blacken-docs` precommit hooks with `ruff-format` hook
* Applied `ruff` formatting to codebase

Closes #2017