### PR TITLE
fix add_history_entry validation to ignore custom schema

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -73,4 +73,5 @@ jobs:
         - linux: weldx
         - linux: sunpy
         - linux: dkist
+        - linux: dkist-inventory
         - linux: abacusutils

--- a/asdf/_asdf.py
+++ b/asdf/_asdf.py
@@ -1131,6 +1131,7 @@ class AsdfFile:
         schema.validate(
             yamlutil.custom_tree_to_tagged_tree({"entry": entry}, self),
             ctx=self,
+            schema={},
         )
 
         if self.version >= versioning.NEW_HISTORY_FORMAT_MIN_VERSION:

--- a/asdf/_tests/test_history.py
+++ b/asdf/_tests/test_history.py
@@ -294,3 +294,18 @@ def test_history_validate():
         # Intentionally incorrect entry type
         af.add_history_entry(1)  # pyrefly: ignore[bad-argument-type]
     assert len(af.get_history_entries()) == 1
+
+
+def test_history_ignores_custom_schema(tmp_path):
+    """
+    Test that add_history_entry doesn't use any provided custom schema.
+    """
+    fn = tmp_path / "custom.yaml"
+    with open(fn, "w") as f:
+        f.write("required: ['foo']")
+    af = asdf.AsdfFile(version="1.6.0", custom_schema=fn)
+    with pytest.raises(ValidationError):
+        af.validate()
+
+    af.add_history_entry("test")
+    assert af.get_history_entries()[0]["description"] == "test"

--- a/changes/2044.bugfix.rst
+++ b/changes/2044.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug where ``add_history_entry`` incorrectly used a custom schema if available.

--- a/tox.ini
+++ b/tox.ini
@@ -334,7 +334,7 @@ commands_pre =
     pip install -r {env_tmp_dir}/asdf_requirement.txt
     pip freeze
 commands =
-    pytest
+    pytest -n auto
 
 [testenv:abacusutils]
 change_dir = {env_tmp_dir}

--- a/tox.ini
+++ b/tox.ini
@@ -321,6 +321,21 @@ commands_pre =
 commands =
     pytest --benchmark-skip
 
+[testenv:dkist-inventory]
+change_dir = {env_tmp_dir}
+allowlist_externals =
+    git
+    bash
+extras =
+commands_pre =
+    git clone https://bitbucket.org/dkistdc/dkist-inventory.git .
+    bash -c "pip freeze -q | grep 'asdf @' > {env_tmp_dir}/asdf_requirement.txt"
+    pip install -e ".[test]"
+    pip install -r {env_tmp_dir}/asdf_requirement.txt
+    pip freeze
+commands =
+    pytest
+
 [testenv:abacusutils]
 change_dir = {env_tmp_dir}
 allowlist_externals =


### PR DESCRIPTION
## Description

This fixes a bug introduced by https://github.com/asdf-format/asdf/pull/2029 where if a user:
- provides a custom schema that constrains the entire tree (like is the case for [dkist](https://github.com/DKISTDC/dkist/blob/a7dc385cc0c30523a93fe1e14a4f4a926bfcda2d/dkist/io/level_1_dataset_schema.yaml#L6))
- calls add_history_entry

The call to `add_history_entry` can fail due to the validation:
- not including the entire tree
- (incorrectly) using the custom schema

This PR fixes the issue by providing a blank schema to `validate` (which will be used instead of the custom schema). The tagged entry will still be validated.

Hopefully we can get some confirmation from dkist that this fixes the issues they had with asdf 5.3.0. Unfortunately this was only revealed in tests for https://bitbucket.org/dkistdc/dkist-inventory/src which we did not have in our downstream. This PR also adds that to our downstream.

## Tasks

- [ ] [run `prek` on your machine](https://prek.j178.dev/quickstart/)
- [ ] run `pytest` on your machine
- [ ] Does this PR add new features and / or change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
    - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
    - [ ] update relevant docstrings and / or `docs/` page
    - [ ] for any new features, add unit tests

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: bug fix
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
