### PR TITLE
suggestion: interval dependabot PRs monthly, and for GitHub Actions ones group them together and cooldown by a week

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,20 @@
 version: 2
 updates:
 
-  # Maintain dependencies for GitHub Actions (main)
   - package-ecosystem: "github-actions"
     directory: "/"
     target-branch: "main"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    groups:
+      actions:
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 7
 
-  # Maintain dependencies for pip (main)
   - package-ecosystem: "pip"
     directory: "/"
     target-branch: "main"
     schedule:
-      interval: "weekly"
+      interval: "monthly"


### PR DESCRIPTION
<!---
Thanks for contributing to asdf!

Your PR should trigger the CI (after approval for first-time contributors)
which will:

- check your code for 'style' using prek
- run your PR against the asdf unit tests for various OSes, python versions, and dependency versions
- perform a test build of your PR

It is highly recommended that you run some of these tests locally by:

- [installing prek](https://prek.j178.dev/quickstart/)
- [running pytest](https://docs.pytest.org/en/7.1.x/getting-started.html)

This will increase the chances your PR will pass the required CI tests.
-->

## Description

<!--
Please describe what this PR accomplishes.
If the changes are non-obvious, please explain how they work.
If this PR adds a new feature please include tests and documentation.
If this PR fixes an issue, please add closing keywords (eg 'fixes #XXX')
-->

to reduce the amount of PRs we get from dependabot; I don't think pin updates are critical enough for this project to merit weekly PRs, but I may be wrong. Thoughts?

## Tasks

- [x] [run `prek` on your machine](https://prek.j178.dev/quickstart/)
- [ ] run `pytest` on your machine
- [ ] Does this PR add new features and / or change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
    - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
    - [ ] update relevant docstrings and / or `docs/` page
    - [ ] for any new features, add unit tests

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: bug fix
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
