### PR TITLE
Add type hints to block and IO APIs

### DIFF
--- a/asdf/_asdf.py
+++ b/asdf/_asdf.py
@@ -5,6 +5,7 @@ import datetime
 import io
 import os
 import time
+import typing
 import warnings
 import weakref
 from typing import TYPE_CHECKING, overload
@@ -1258,7 +1259,11 @@ class AsdfFile:
                 if block.header["compression"] == b"\0\0\0\0":
                     compression = "None"
                 else:
-                    compression = block.header["compression"].rstrip(b"\0").decode("ascii", errors="backslashreplace")
+                    compression = (
+                        typing.cast("bytes", block.header["compression"])
+                        .rstrip(b"\0")
+                        .decode("ascii", errors="backslashreplace")
+                    )
                     compression = f'"{compression}"'
 
                 items = [

--- a/asdf/_asdf.py
+++ b/asdf/_asdf.py
@@ -7,7 +7,7 @@ import os
 import time
 import warnings
 import weakref
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, overload
 
 from packaging.version import Version
 
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
 
     from asdf.extension import ExtensionManager, SerializationContext
     from asdf.generic_io import GenericFile
+    from asdf.tagged import Tagged
     from asdf.typing import (
         ArrayStorage,
         AsdfVersionLike,
@@ -501,7 +502,7 @@ class AsdfFile:
         """
         return self._blocks._uri
 
-    def resolve_uri(self, uri: str | None) -> str:
+    def resolve_uri(self, uri: str) -> str:
         """
         Resolve a (possibly relative) URI against the URI of this ASDF
         file.  May be overridden by base classes to change how URIs
@@ -591,7 +592,12 @@ class AsdfFile:
         """
         return self._comments
 
-    def _validate(self, tree: AsdfObject, reading: bool = False) -> None:
+    @overload
+    def _validate(self, tree: Tagged, reading: bool = True) -> None: ...
+    @overload
+    def _validate(self, tree: AsdfObject, reading: bool = False) -> None: ...
+
+    def _validate(self, tree, reading: bool = False) -> None:
         with self._blocks.options_context():
             # If we're validating on read then the tree
             # is already guaranteed to be in tagged form.

--- a/asdf/_block/callback.py
+++ b/asdf/_block/callback.py
@@ -15,7 +15,14 @@ operations that we generally do not want to expose to
 extension code.
 """
 
+from __future__ import annotations
+
 import weakref
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from asdf._block.manager import ReadBlocks
+    from asdf.typing import ByteArray1D
 
 
 class DataCallback:
@@ -24,10 +31,10 @@ class DataCallback:
     read from an ASDF file.
     """
 
-    def __init__(self, index, read_blocks):
+    def __init__(self, index: int, read_blocks: ReadBlocks):
         self._reassign(index, read_blocks)
 
-    def __call__(self, _attr=None):
+    def __call__(self, _attr: str | None = None) -> ByteArray1D:
         read_blocks = self._read_blocks_ref()
         if read_blocks is None:
             msg = "Attempt to read block data from missing block"
@@ -39,6 +46,6 @@ class DataCallback:
             # like reading the header and cached_data
             return getattr(read_blocks[self._index], _attr)
 
-    def _reassign(self, index, read_blocks):
+    def _reassign(self, index: int, read_blocks: ReadBlocks) -> None:
         self._index = index
         self._read_blocks_ref = weakref.ref(read_blocks)

--- a/asdf/_block/external.py
+++ b/asdf/_block/external.py
@@ -8,26 +8,42 @@ the block manager to have a reference to the `AsdfFile`
 (that references the block manager).
 """
 
+from __future__ import annotations
+
+import enum
 import os
 import urllib
+import urllib.request
+from typing import TYPE_CHECKING, Final, Literal
 
 import numpy as np
 
 from asdf import generic_io, util
 
+if TYPE_CHECKING:
+    from asdf.typing import ByteArray1D
 
-class UseInternalType:
-    pass
+
+class _USE_INTERNAL_TYPE(enum.Enum):
+    USE_INTERNAL = "UseInternal"
+
+    def __repr__(self) -> str:
+        return str(self.value)
 
 
-UseInternal = UseInternalType()
+USE_INTERNAL: Final = _USE_INTERNAL_TYPE.USE_INTERNAL
+
+#: Type corresponding to ``USE_INTERNAL`` value for use in type-checking
+UseInternal: Final = Literal[_USE_INTERNAL_TYPE.USE_INTERNAL]
 
 
 class ExternalBlockCache:
     def __init__(self):
         self.clear()
 
-    def load(self, base_uri, uri, memmap=False, validate_checksums=False):
+    def load(
+        self, base_uri: str | None, uri: str, memmap: bool = False, validate_checksums: bool = False
+    ) -> ByteArray1D | UseInternal:
         key = util.get_base_uri(uri)
         if key not in self._cache:
             resolved_uri = generic_io.resolve_uri(base_uri, uri)
@@ -37,7 +53,7 @@ class ExternalBlockCache:
             if resolved_uri.endswith("#"):
                 resolved_uri = resolved_uri[:-1]
             if resolved_uri == "" or resolved_uri == base_uri:
-                return UseInternal
+                return USE_INTERNAL
 
             from asdf import open as asdf_open
 
@@ -47,7 +63,7 @@ class ExternalBlockCache:
                 blk = af._blocks.blocks[0]
                 if memmap and blk.header["compression"] == b"\0\0\0\0":
                     parsed_url = util._patched_urllib_parse.urlparse(resolved_uri)
-                    if parsed_url.scheme == "file":
+                    if parsed_url.scheme == "file" and blk.data_offset is not None:
                         # deal with leading slash for windows file://
                         filename = urllib.request.url2pathname(parsed_url.path)
                         arr = np.memmap(filename, np.uint8, "r", blk.data_offset, blk.cached_data.nbytes)
@@ -58,11 +74,11 @@ class ExternalBlockCache:
             self._cache[key] = arr
         return self._cache[key]
 
-    def clear(self):
+    def clear(self) -> None:
         self._cache = {}
 
 
-def relative_uri_for_index(uri, index):
+def relative_uri_for_index(uri: str, index: int) -> str:
     # get the os-native separated path for this uri
     path = util._patched_urllib_parse.urlparse(uri).path
     _, filename = os.path.split(path)

--- a/asdf/_block/io.py
+++ b/asdf/_block/io.py
@@ -48,7 +48,7 @@ BLOCK_HEADER = util._BinaryStruct(
 )
 
 
-def calculate_block_checksum(data):
+def calculate_block_checksum(data) -> bytes:
     # The following line is safe because we're only using
     # the MD5 as a checksum.
     m = hashlib.new("md5", usedforsecurity=False)

--- a/asdf/_block/io.py
+++ b/asdf/_block/io.py
@@ -14,7 +14,6 @@ import weakref
 from typing import TYPE_CHECKING, Any, TypedDict
 
 import yaml
-from typing_extensions import Unpack
 
 from asdf import _compression as mcompression
 from asdf import constants, generic_io, util
@@ -23,20 +22,24 @@ from asdf.versioning import _yaml_base_loader as BaseLoader
 from .exceptions import BlockIndexError
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator, Sequence
+
+    from typing_extensions import Buffer, Unpack
+
     from asdf.generic_io import GenericFile
-    from asdf.typing import BlockDataCallback, ByteArray1D
+    from asdf.typing import BlockDataCallback, ByteArray1D, Compression
 
 
 class BlockHeader(TypedDict, total=False):
     flags: int
-    compression: bytes
+    compression: Compression
     allocated_size: int
     used_size: int
     data_size: int
     checksum: bytes
 
 
-BLOCK_HEADER = util._BinaryStruct(
+BLOCK_HEADER: util._BinaryStruct = util._BinaryStruct(
     [
         ("flags", "I"),
         ("compression", "4s"),
@@ -48,7 +51,7 @@ BLOCK_HEADER = util._BinaryStruct(
 )
 
 
-def calculate_block_checksum(data) -> bytes:
+def calculate_block_checksum(data: Buffer) -> bytes:
     # The following line is safe because we're only using
     # the MD5 as a checksum.
     m = hashlib.new("md5", usedforsecurity=False)
@@ -123,7 +126,7 @@ def read_block_header(fd: GenericFile, offset: int | None = None) -> BlockHeader
 
 
 def read_block_data(
-    fd: GenericFile, header, validate_checksum: bool, offset: int | None = None, memmap: bool = False
+    fd: GenericFile, header: BlockHeader, validate_checksum: bool, offset: int | None = None, memmap: bool = False
 ) -> ByteArray1D:
     """
     Read (or memory map) data for an ASDF block.
@@ -211,7 +214,7 @@ def read_block_data(
             fd.fast_forward(ff_bytes)
 
         if validate_checksum and has_checksum:
-            checksum = calculate_block_checksum(data)
+            checksum = calculate_block_checksum(data)  # pyrefly: ignore [bad-argument-type]
             if header["checksum"] != checksum:
                 msg = f"Block at {offset} does not match given checksum"
                 raise ValueError(msg)
@@ -301,7 +304,7 @@ def generate_write_header(
     data: ByteArray1D,
     stream: bool = False,
     compression_kwargs: dict[str, Any] | None = None,
-    padding: bool | float = False,
+    padding: bool | float | None = False,
     fs_block_size: int = 1,
     write_checksum: bool = True,
     **header_kwargs: Unpack[BlockHeader],
@@ -405,8 +408,15 @@ def generate_write_header(
 
 
 def write_block(
-    fd, data, offset=None, stream=False, compression_kwargs=None, padding=False, write_checksum=True, **header_kwargs
-):
+    fd: GenericFile,
+    data: ByteArray1D,
+    offset: int | None = None,
+    stream: bool = False,
+    compression_kwargs: dict[str, Any] | None = None,
+    padding: bool | float | None = False,
+    write_checksum: bool = True,
+    **header_kwargs: Unpack[BlockHeader],
+) -> BlockHeader:
     """
     Write an ASDF block.
 
@@ -463,7 +473,7 @@ def write_block(
     return header_dict
 
 
-def _candidate_offsets(min_offset, max_offset, block_size):
+def _candidate_offsets(min_offset: int, max_offset: int, block_size: int) -> Iterator[int]:
     offset = (max_offset // block_size) * block_size
     if offset == max_offset:
         offset -= block_size
@@ -526,7 +536,7 @@ def find_block_index(fd: GenericFile, min_offset: int | None = None, max_offset:
     return block_index_offset
 
 
-def read_block_index(fd, offset=None):
+def read_block_index(fd: GenericFile, offset: int | None = None) -> list[int | None]:
     """
     Read an ASDF block index from a file.
 
@@ -578,7 +588,12 @@ def read_block_index(fd, offset=None):
     return block_index
 
 
-def write_block_index(fd, offsets, offset=None, yaml_version=None):
+def write_block_index(
+    fd: GenericFile,
+    offsets: Sequence[int | None],
+    offset: int | None = None,
+    yaml_version: tuple[int, int] | None = None,
+) -> None:
     """
     Write a list of ASDF block offsets to a file in the form
     of an ASDF block index.

--- a/asdf/_block/io.py
+++ b/asdf/_block/io.py
@@ -3,19 +3,38 @@ Low-level functions for reading and writing ASDF blocks
 and other block related file contents (like the block index).
 """
 
+from __future__ import annotations
+
 import hashlib
 import io
 import os
 import struct
+import typing
 import weakref
+from typing import TYPE_CHECKING, Any, TypedDict
 
 import yaml
+from typing_extensions import Unpack
 
 from asdf import _compression as mcompression
 from asdf import constants, generic_io, util
 from asdf.versioning import _yaml_base_loader as BaseLoader
 
 from .exceptions import BlockIndexError
+
+if TYPE_CHECKING:
+    from asdf.generic_io import GenericFile
+    from asdf.typing import BlockDataCallback, ByteArray1D
+
+
+class BlockHeader(TypedDict, total=False):
+    flags: int
+    compression: bytes
+    allocated_size: int
+    used_size: int
+    data_size: int
+    checksum: bytes
+
 
 BLOCK_HEADER = util._BinaryStruct(
     [
@@ -37,7 +56,7 @@ def calculate_block_checksum(data):
     return m.digest()
 
 
-def validate_block_header(header):
+def validate_block_header(header: BlockHeader) -> BlockHeader:
     """
     Check that they key value pairs in header contain consistent
     information about the ASDF block ``compression``, ``flags``,
@@ -65,7 +84,7 @@ def validate_block_header(header):
     return header
 
 
-def read_block_header(fd, offset=None):
+def read_block_header(fd: GenericFile, offset: int | None = None) -> BlockHeader:
     """
     Read an ASDF block header
 
@@ -100,11 +119,12 @@ def read_block_header(fd, offset=None):
         msg = f"Header size must be >= {BLOCK_HEADER.size}"
         raise ValueError(msg)
 
-    header = BLOCK_HEADER.unpack(fd.read(header_size))
-    return validate_block_header(header)
+    return typing.cast("BlockHeader", BLOCK_HEADER.unpack(fd.read(header_size)))
 
 
-def read_block_data(fd, header, validate_checksum, offset=None, memmap=False):
+def read_block_data(
+    fd: GenericFile, header, validate_checksum: bool, offset: int | None = None, memmap: bool = False
+) -> ByteArray1D:
     """
     Read (or memory map) data for an ASDF block.
 
@@ -179,7 +199,7 @@ def read_block_data(fd, header, validate_checksum, offset=None, memmap=False):
             data = mcompression.decompress(fd, used_size, header["data_size"], compression)
             fd.fast_forward(header["allocated_size"] - header["used_size"])
     else:
-        if memmap and fd.can_memmap():
+        if memmap and fd.can_memmap() and offset is not None:
             data = fd.memmap_array(offset, used_size)
             ff_bytes = header["allocated_size"]
         else:
@@ -198,7 +218,9 @@ def read_block_data(fd, header, validate_checksum, offset=None, memmap=False):
     return data
 
 
-def read_block(fd, validate_checksum, offset=None, memmap=False, lazy_load=False):
+def read_block(
+    fd: GenericFile, validate_checksum: bool, offset: int | None = None, memmap: bool = False, lazy_load: bool = False
+) -> tuple[int | None, BlockHeader, int | None, ByteArray1D | BlockDataCallback]:
     """
     Read a block (header and data) from an ASDF file.
 
@@ -255,7 +277,7 @@ def read_block(fd, validate_checksum, offset=None, memmap=False, lazy_load=False
         # setup a callback to later load the data
         fd_ref = weakref.ref(fd)
 
-        def callback():
+        def callback() -> ByteArray1D:
             fd = fd_ref()
             if fd is None or fd.is_closed():
                 msg = "ASDF file has already been closed. Can not get the data."
@@ -276,8 +298,14 @@ def read_block(fd, validate_checksum, offset=None, memmap=False, lazy_load=False
 
 
 def generate_write_header(
-    data, stream=False, compression_kwargs=None, padding=False, fs_block_size=1, write_checksum=True, **header_kwargs
-):
+    data: ByteArray1D,
+    stream: bool = False,
+    compression_kwargs: dict[str, Any] | None = None,
+    padding: bool | float = False,
+    fs_block_size: int = 1,
+    write_checksum: bool = True,
+    **header_kwargs: Unpack[BlockHeader],
+) -> tuple[BlockHeader, io.BytesIO | None, int]:
     """
     Generate a dict representation of a ASDF block header that can be
     used for writing a block.
@@ -446,7 +474,7 @@ def _candidate_offsets(min_offset, max_offset, block_size):
         yield min_offset
 
 
-def find_block_index(fd, min_offset=None, max_offset=None):
+def find_block_index(fd: GenericFile, min_offset: int | None = None, max_offset: int | None = None) -> int | None:
     """
     Find the location of an ASDF block index within a seekable file.
 

--- a/asdf/_block/key.py
+++ b/asdf/_block/key.py
@@ -26,6 +26,8 @@ of these Key instances all methods and attributes
 are private.
 """
 
+from __future__ import annotations
+
 import weakref
 from typing import Any
 
@@ -69,7 +71,7 @@ class Key:
             return False
         return r is obj
 
-    def __eq__(self, other) -> bool:
+    def __eq__(self, other: Any) -> bool:
         if not isinstance(other, Key):
             return NotImplemented
         if self._key != other._key:
@@ -78,6 +80,6 @@ class Key:
             return False
         return other._matches_object(self._ref())  # pyrefly: ignore [not-callable]
 
-    def __copy__(self):
+    def __copy__(self) -> Key:
         obj = self._ref if self._ref is None else self._ref()
         return type(self)(obj, self._key)

--- a/asdf/_block/key.py
+++ b/asdf/_block/key.py
@@ -27,6 +27,7 @@ are private.
 """
 
 import weakref
+from typing import Any
 
 
 class Key:
@@ -38,15 +39,15 @@ class Key:
         cls._next += 1
         return key
 
-    def __init__(self, obj=None, _key=None):
+    def __init__(self, obj: Any | None = None, _key: int | None = None):
         if _key is None:
             _key = Key._next_key()
         self._key = _key
-        self._ref = None
+        self._ref: Any | None = None
         if obj is not None:
             self._assign_object(obj)
 
-    def _is_valid(self):
+    def _is_valid(self) -> bool:
         if self._ref is None:
             return False
         r = self._ref()
@@ -54,10 +55,10 @@ class Key:
             return False
         return True
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return self._key
 
-    def _assign_object(self, obj):
+    def _assign_object(self, obj: Any) -> None:
         self._ref = weakref.ref(obj)
 
     def _matches_object(self, obj):
@@ -68,14 +69,14 @@ class Key:
             return False
         return r is obj
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         if not isinstance(other, Key):
             return NotImplemented
         if self._key != other._key:
             return False
         if not self._is_valid():
             return False
-        return other._matches_object(self._ref())
+        return other._matches_object(self._ref())  # pyrefly: ignore [not-callable]
 
     def __copy__(self):
         obj = self._ref if self._ref is None else self._ref()

--- a/asdf/_block/manager.py
+++ b/asdf/_block/manager.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import collections
 import contextlib
 import copy
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, overload
 
 from asdf import config, constants, generic_io, util
 from asdf._block.reader import ReadBlock
@@ -16,8 +16,9 @@ from .key import Key as BlockKey
 from .options import Options
 
 if TYPE_CHECKING:
-    from collections.abc import Generator, Sequence
+    from collections.abc import Generator, Iterator, Sequence
 
+    from asdf._block.key import Key
     from asdf.generic_io import GenericFile
     from asdf.typing import ArrayStorage, BlockDataCallback, ByteArray1D, Compression, NDArray
 
@@ -56,19 +57,24 @@ class WriteBlocks(collections.abc.Sequence[WriteBlock]):
         self._data_store = store.Store()
         self._object_store = store.Store()
 
+    @overload
+    def __getitem__(self, index: int) -> WriteBlock: ...
+    @overload
+    def __getitem__(self, index: slice[int | None]) -> Sequence[WriteBlock]: ...
+
     def __getitem__(self, index):
         return self._blocks.__getitem__(index)
 
     def __len__(self) -> int:
         return self._blocks.__len__()
 
-    def index_for_data(self, data):
+    def index_for_data(self, data: Any) -> Any | None:
         return self._data_store.lookup_by_object(data)
 
-    def assign_object_to_index(self, obj, index):
+    def assign_object_to_index(self, obj: Any, index: int) -> None:
         self._object_store.assign_object(obj, index)
 
-    def object_keys_for_index(self, index):
+    def object_keys_for_index(self, index: int) -> Iterator[Key]:
         yield from self._object_store.keys_for_value(index)
 
     def append_block(self, blk: WriteBlock, obj: Any) -> int:
@@ -106,7 +112,7 @@ class OptionsStore(store.Store):
         # ReadBlocks are needed to look up default options
         self._read_blocks = read_blocks
 
-    def has_options(self, array):
+    def has_options(self, array: NDArray) -> bool:
         """
         Check of Options have been defined for this array
         without falling back to generating Options from
@@ -301,7 +307,7 @@ class Manager:
     ):
         if read_blocks is None:
             read_blocks = ReadBlocks([])
-        self.options = OptionsStore(read_blocks)
+        self.options: OptionsStore = OptionsStore(read_blocks)
 
         self._blocks = read_blocks
         self._external_block_cache = external.ExternalBlockCache()
@@ -511,7 +517,7 @@ class Manager:
     def _get_array_compression_kwargs(self, arr):
         return self.options.get_options(arr).compression_kwargs
 
-    def get_output_compressions(self):
+    def get_output_compressions(self) -> set[Compression]:
         return self.options.get_output_compressions()
 
     def _set_array_save_base(self, data, save_base):
@@ -715,7 +721,7 @@ class Manager:
 
                 # update all callbacks
                 for obj_key in obj_keys:
-                    obj = obj_key._ref()
+                    obj = obj_key._ref()  # pyrefly: ignore [not-callable]
                     if obj is None:
                         # this object no longer exists so don't both assigning it
                         continue

--- a/asdf/_block/manager.py
+++ b/asdf/_block/manager.py
@@ -1,8 +1,13 @@
+from __future__ import annotations
+
 import collections
 import contextlib
 import copy
+from typing import TYPE_CHECKING, Any
 
 from asdf import config, constants, generic_io, util
+from asdf._block.reader import ReadBlock
+from asdf._block.writer import WriteBlock
 
 from . import external, reader, store, writer
 from . import io as bio
@@ -10,8 +15,14 @@ from .callback import DataCallback
 from .key import Key as BlockKey
 from .options import Options
 
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
-class ReadBlocks(collections.UserList):
+    from asdf.generic_io import GenericFile
+    from asdf.typing import ArrayStorage, BlockDataCallback, ByteArray1D, Compression, NDArray
+
+
+class ReadBlocks(collections.UserList[ReadBlock]):
     """
     A list of ReadBlock instances.
 
@@ -23,7 +34,7 @@ class ReadBlocks(collections.UserList):
     pass
 
 
-class WriteBlocks(collections.abc.Sequence):
+class WriteBlocks(collections.abc.Sequence[WriteBlock]):
     """
     A collection of ``WriteBlock`` instances that can be accessed by:
         - numerical index (see ``collections.abc.Sequence``)
@@ -35,7 +46,7 @@ class WriteBlocks(collections.abc.Sequence):
     a reference to the block data).
     """
 
-    def __init__(self, blocks=None):
+    def __init__(self, blocks: list[WriteBlock] | None = None):
         if blocks is None:
             blocks = []
         self._blocks = blocks
@@ -48,7 +59,7 @@ class WriteBlocks(collections.abc.Sequence):
     def __getitem__(self, index):
         return self._blocks.__getitem__(index)
 
-    def __len__(self):
+    def __len__(self) -> int:
         return self._blocks.__len__()
 
     def index_for_data(self, data):
@@ -60,7 +71,7 @@ class WriteBlocks(collections.abc.Sequence):
     def object_keys_for_index(self, index):
         yield from self._object_store.keys_for_value(index)
 
-    def append_block(self, blk, obj):
+    def append_block(self, blk: WriteBlock, obj: Any) -> int:
         """
         Append a ``WriteBlock`` instance to this collection
         assign an object, obj, to the block and return
@@ -148,7 +159,7 @@ class OptionsStore(store.Store):
                 return options
         return None
 
-    def get_options(self, array):
+    def get_options(self, array: NDArray) -> Options:
         """
         Get Options for some array using either previously defined
         options (as set by ``set_options``) or settings read from a
@@ -181,7 +192,7 @@ class OptionsStore(store.Store):
             self.set_options(base, options)
         return options
 
-    def set_options(self, array, options):
+    def set_options(self, array: NDArray, options: Options) -> None:
         """
         Set Options for an array.
 
@@ -280,7 +291,14 @@ class Manager:
     to reference the appropriate new ``ReadBlock``.
     """
 
-    def __init__(self, read_blocks=None, uri=None, lazy_load=False, memmap=False, validate_checksums=False):
+    def __init__(
+        self,
+        read_blocks: ReadBlocks | None = None,
+        uri: str | None = None,
+        lazy_load: bool = False,
+        memmap: bool = False,
+        validate_checksums: bool = False,
+    ):
         if read_blocks is None:
             read_blocks = ReadBlocks([])
         self.options = OptionsStore(read_blocks)
@@ -305,7 +323,7 @@ class Manager:
         self._memmap = memmap
         self._validate_checksums = validate_checksums
 
-    def close(self):
+    def close(self) -> None:
         self._external_block_cache.clear()
         self._clear_write()
         for blk in self.blocks:
@@ -313,7 +331,7 @@ class Manager:
         self.options = OptionsStore(self.blocks)
 
     @property
-    def blocks(self):
+    def blocks(self) -> ReadBlocks:
         """
         Get any ReadBlocks that were read from an ASDF file
 
@@ -326,7 +344,7 @@ class Manager:
         return self._blocks
 
     @blocks.setter
-    def blocks(self, new_blocks):
+    def blocks(self, new_blocks: Sequence[ReadBlock]) -> None:
         if not isinstance(new_blocks, ReadBlocks):
             new_blocks = ReadBlocks(new_blocks)
         self._blocks = new_blocks
@@ -334,7 +352,7 @@ class Manager:
         # options lookups can fallback to the new read blocks
         self.options._read_blocks = new_blocks
 
-    def read(self, fd, after_magic=False):
+    def read(self, fd: GenericFile, after_magic: bool = False) -> None:
         """
         Read blocks from an ASDF file and update the manager read_blocks.
 
@@ -351,20 +369,20 @@ class Manager:
             fd, self._memmap, self._lazy_load, self._validate_checksums, after_magic=after_magic
         )
 
-    def _load_external(self, uri):
+    def _load_external(self, uri: str) -> ByteArray1D:
         value = self._external_block_cache.load(self._uri, uri, self._memmap, self._validate_checksums)
-        if value is external.UseInternal:
+        if value is external.USE_INTERNAL:
             return self.blocks[0].data
         return value
 
-    def _clear_write(self):
+    def _clear_write(self) -> None:
         self._write_blocks = WriteBlocks()
         self._external_write_blocks = []
         self._streamed_write_block = None
         self._streamed_obj_keys = set()
         self._write_fd = None
 
-    def _write_external_blocks(self, write_checksums):
+    def _write_external_blocks(self, write_checksums: bool) -> None:
         from asdf import AsdfFile
 
         if self._write_fd is None or self._write_fd.uri is None:
@@ -378,7 +396,7 @@ class Manager:
                 af.write_to(f, include_block_index=False)
                 writer.write_blocks(f, [blk], write_checksums=write_checksums)
 
-    def make_write_block(self, data, options, obj):
+    def make_write_block(self, data: ByteArray1D | BlockDataCallback, options: Options | None, obj: Any) -> int | str:
         """
         Make a WriteBlock with data and options and
         associate it with an object (obj).
@@ -441,7 +459,7 @@ class Manager:
         index = self._write_blocks.append_block(blk, obj)
         return index
 
-    def set_streamed_write_block(self, data, obj):
+    def set_streamed_write_block(self, data: ByteArray1D | BlockDataCallback, obj: Any) -> None:
         """
         Create a WriteBlock that will be written as an ASDF
         streamed block.
@@ -465,18 +483,18 @@ class Manager:
             self._streamed_write_block = writer.WriteBlock(data)
         self._streamed_obj_keys.add(BlockKey(obj))
 
-    def _get_data_callback(self, index):
+    def _get_data_callback(self, index: int) -> DataCallback:
         return DataCallback(index, self.blocks)
 
-    def _set_array_storage(self, data, storage):
+    def _set_array_storage(self, data: NDArray, storage: ArrayStorage) -> None:
         options = self.options.get_options(data)
         options.storage_type = storage
         self.options.set_options(data, options)
 
-    def _get_array_storage(self, data):
+    def _get_array_storage(self, data: NDArray) -> ArrayStorage:
         return self.options.get_options(data).storage_type
 
-    def _set_array_compression(self, arr, compression, **compression_kwargs):
+    def _set_array_compression(self, arr: NDArray, compression: Compression, **compression_kwargs) -> None:
         # if this is input compression but we already have defined options
         # we need to re-lookup the options based off the block
         if compression == "input" and self.options.has_options(arr):
@@ -541,7 +559,7 @@ class Manager:
             yield
         self._clear_write()
 
-    def write(self, pad_blocks, include_block_index, write_checksums):
+    def write(self, pad_blocks: bool | float | None, include_block_index: bool, write_checksums: bool) -> None:
         """
         Write blocks that were set up during the current
         `write_context`.
@@ -582,7 +600,9 @@ class Manager:
         if len(self._external_write_blocks):
             self._write_external_blocks(write_checksums=write_checksums)
 
-    def update(self, new_tree_size, pad_blocks, include_block_index, write_checksums):
+    def update(
+        self, new_tree_size: int, pad_blocks: bool | float | None, include_block_index: bool, write_checksums: bool
+    ) -> None:
         """
         Perform an update-in-place of ASDF blocks set up during
         a `write_context`.
@@ -625,6 +645,9 @@ class Manager:
             break
         if last_block is None:
             new_block_start = new_tree_size
+        elif last_block.data_offset is None:
+            msg = "Unable to update ASDF file because source file is not seekable"
+            raise RuntimeError(msg)
         else:
             new_block_start = max(
                 last_block.data_offset + last_block.header["allocated_size"],
@@ -661,8 +684,15 @@ class Manager:
                 src += n
                 dst += n
 
+            def update_offset(offset: int | None) -> int:
+                if offset is None:
+                    msg = "Unable to update ASDF file because source file is not seekable"
+                    raise RuntimeError(msg)
+
+                return offset - (new_block_start - new_tree_size)
+
             # update offset to point at correct locations
-            offsets = [o - (new_block_start - new_tree_size) for o in offsets]
+            offsets = [update_offset(o) for o in offsets]
 
             # write index if no streamed block
             if include_block_index and self._streamed_write_block is None:

--- a/asdf/_block/manager.py
+++ b/asdf/_block/manager.py
@@ -16,7 +16,7 @@ from .key import Key as BlockKey
 from .options import Options
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Generator, Sequence
 
     from asdf.generic_io import GenericFile
     from asdf.typing import ArrayStorage, BlockDataCallback, ByteArray1D, Compression, NDArray
@@ -101,7 +101,7 @@ class OptionsStore(store.Store):
     ``ReadBlock`` to determine default Options.
     """
 
-    def __init__(self, read_blocks):
+    def __init__(self, read_blocks: Sequence[ReadBlock]):
         super().__init__()
         # ReadBlocks are needed to look up default options
         self._read_blocks = read_blocks
@@ -126,7 +126,7 @@ class OptionsStore(store.Store):
         base = util.get_array_base(array)
         return self.lookup_by_object(base) is not None
 
-    def get_options_from_block(self, array):
+    def get_options_from_block(self, array: NDArray) -> Options | None:
         """
         Get Options for some array using only settings read from a
         corresponding ReadBlock (one that shares the same base array).
@@ -223,7 +223,7 @@ class OptionsStore(store.Store):
         base = util.get_array_base(array)
         self.assign_object(base, options)
 
-    def get_output_compressions(self):
+    def get_output_compressions(self) -> set[Compression]:
         """
         Get all output compression types used for this Store of
         Options.
@@ -233,7 +233,7 @@ class OptionsStore(store.Store):
         compressions : list of bytes
             List of 4 byte compression labels used for this OptionsStore.
         """
-        compressions = set()
+        compressions: set[Compression] = set()
         cfg = config.get_config()
         if cfg.all_array_compression == "input":
             for blk in self._read_blocks:
@@ -311,7 +311,7 @@ class Manager:
         self._external_write_blocks = []
         self._streamed_write_block = None
         self._streamed_obj_keys = set()
-        self._write_fd = None
+        self._write_fd: GenericFile | None = None
 
         # store the uri of the ASDF file here so that the Manager can
         # resolve and load external blocks without requiring a reference
@@ -523,7 +523,7 @@ class Manager:
         return self.options.get_options(data).save_base
 
     @contextlib.contextmanager
-    def options_context(self):
+    def options_context(self) -> Generator[None]:
         """
         Context manager that copies block options on
         entrance and restores the options when exited.
@@ -534,7 +534,7 @@ class Manager:
         self.options._read_blocks = self.blocks
 
     @contextlib.contextmanager
-    def write_context(self, fd, copy_options=True):
+    def write_context(self, fd: GenericFile, copy_options: bool = True) -> Generator[None]:
         """
         Context manager that copies block options on
         entrance and restores the options when exited.

--- a/asdf/_block/options.py
+++ b/asdf/_block/options.py
@@ -1,5 +1,12 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
 from asdf import _compression as mcompression
 from asdf.config import get_config
+
+if TYPE_CHECKING:
+    from asdf.typing import ArrayStorage, Compression
 
 
 class Options:
@@ -7,7 +14,13 @@ class Options:
     Storage and compression options useful when reading or writing ASDF blocks.
     """
 
-    def __init__(self, storage_type=None, compression_type=None, compression_kwargs=None, save_base=None):
+    def __init__(
+        self,
+        storage_type: ArrayStorage = None,
+        compression_type: Compression = None,
+        compression_kwargs: dict[str, Any] | None = None,
+        save_base: bool | None = None,
+    ):
         if storage_type is None:
             storage_type = get_config().all_array_storage or "internal"
         if save_base is None:
@@ -15,31 +28,30 @@ class Options:
 
         self._storage_type = None
         self._compression = None
-        self._compression_kwargs = None
+        self._compression_kwargs: dict[str, Any] = compression_kwargs or {}
 
         # set via setters
-        self.compression_kwargs = compression_kwargs
         self.compression = compression_type
         self.storage_type = storage_type
         self.save_base = save_base
 
     @property
-    def storage_type(self):
+    def storage_type(self) -> ArrayStorage:
         return self._storage_type
 
     @storage_type.setter
-    def storage_type(self, storage_type):
+    def storage_type(self, storage_type: ArrayStorage) -> None:
         if storage_type not in ["internal", "external", "streamed", "inline"]:
             msg = "array_storage must be one of 'internal', 'external', 'streamed' or 'inline'"
             raise ValueError(msg)
         self._storage_type = storage_type
 
     @property
-    def compression(self):
+    def compression(self) -> Compression:
         return self._compression
 
     @compression.setter
-    def compression(self, compression):
+    def compression(self, compression: Compression) -> None:
         msg = f"Invalid compression type: {compression}"
         if compression == "input":
             # "input" compression will validate as the ASDF compression module made
@@ -56,21 +68,21 @@ class Options:
         self._compression = compression
 
     @property
-    def compression_kwargs(self):
+    def compression_kwargs(self) -> dict[str, Any]:
         return self._compression_kwargs
 
     @compression_kwargs.setter
-    def compression_kwargs(self, kwargs):
+    def compression_kwargs(self, kwargs: dict[str, Any] | None) -> None:
         if not kwargs:
             kwargs = {}
         self._compression_kwargs = kwargs
 
     @property
-    def save_base(self):
+    def save_base(self) -> bool | None:
         return self._save_base
 
     @save_base.setter
-    def save_base(self, save_base):
+    def save_base(self, save_base: bool | None) -> None:
         if not (isinstance(save_base, bool) or save_base is None):
             msg = "save_base must be a bool or None"
             raise ValueError(msg)

--- a/asdf/_block/options.py
+++ b/asdf/_block/options.py
@@ -88,5 +88,5 @@ class Options:
             raise ValueError(msg)
         self._save_base = save_base
 
-    def __copy__(self):
+    def __copy__(self) -> Options:
         return type(self)(self._storage_type, self._compression, self._compression_kwargs)

--- a/asdf/_block/reader.py
+++ b/asdf/_block/reader.py
@@ -33,15 +33,15 @@ class ReadBlock:
         data_offset: int | None = None,
         data: ByteArray1D | BlockDataCallback | None = None,
     ):
-        self.offset = offset  # after block magic bytes
+        self.offset: int | None = offset  # after block magic bytes
         self._fd = weakref.ref(fd)
         self._header = header
-        self.data_offset = data_offset
+        self.data_offset: int | None = data_offset
         self._data = data
         self._cached_data = None
-        self.memmap = memmap
-        self.lazy_load = lazy_load
-        self.validate_checksum = validate_checksum
+        self.memmap: bool = memmap
+        self.lazy_load: bool = lazy_load
+        self.validate_checksum: bool = validate_checksum
         if not lazy_load:
             self.load()
 
@@ -251,12 +251,15 @@ def read_blocks(
         return _read_blocks_serially(fd, memmap, lazy_load, validate_checksums, after_magic)
     # skip magic for each block
     magic_len = len(constants.BLOCK_MAGIC)
-    blocks = [ReadBlock(offset + magic_len, fd, memmap, lazy_load, validate_checksums) for offset in block_index]
+    blocks = [
+        ReadBlock(offset + magic_len if offset is not None else None, fd, memmap, lazy_load, validate_checksums)
+        for offset in block_index
+    ]
 
     # load first and last blocks to check if the index looks correct
     for index in (0, -1):
         try:
-            fd.seek(block_index[index])
+            fd.seek(typing.cast("int", block_index[index]))
             buff = fd.read(magic_len)
             if buff != constants.BLOCK_MAGIC:
                 msg = "Invalid block magic"

--- a/asdf/_block/reader.py
+++ b/asdf/_block/reader.py
@@ -1,5 +1,9 @@
+from __future__ import annotations
+
+import typing
 import warnings
 import weakref
+from typing import TYPE_CHECKING
 
 from asdf import constants
 from asdf.exceptions import AsdfBlockIndexWarning, AsdfWarning, DelimiterNotFoundError
@@ -7,13 +11,28 @@ from asdf.exceptions import AsdfBlockIndexWarning, AsdfWarning, DelimiterNotFoun
 from . import io as bio
 from .exceptions import BlockIndexError
 
+if TYPE_CHECKING:
+    from asdf._block.io import BlockHeader
+    from asdf.generic_io import GenericFile
+    from asdf.typing import BlockDataCallback, ByteArray1D
+
 
 class ReadBlock:
     """
     Represents an ASDF block read from a file.
     """
 
-    def __init__(self, offset, fd, memmap, lazy_load, validate_checksum, header=None, data_offset=None, data=None):
+    def __init__(
+        self,
+        offset: int | None,
+        fd: GenericFile,
+        memmap: bool,
+        lazy_load: bool,
+        validate_checksum: bool,
+        header: BlockHeader | None = None,
+        data_offset: int | None = None,
+        data: ByteArray1D | BlockDataCallback | None = None,
+    ):
         self.offset = offset  # after block magic bytes
         self._fd = weakref.ref(fd)
         self._header = header
@@ -26,14 +45,14 @@ class ReadBlock:
         if not lazy_load:
             self.load()
 
-    def close(self):
+    def close(self) -> None:
         self._cached_data = None
 
     @property
-    def loaded(self):
+    def loaded(self) -> bool:
         return self._data is not None
 
-    def load(self):
+    def load(self) -> None:
         """
         Load the block data (if it is not already loaded).
 
@@ -55,7 +74,7 @@ class ReadBlock:
         fd.seek(position)
 
     @property
-    def data(self):
+    def data(self) -> ByteArray1D:
         """
         Read, parse and return data for an ASDF block.
 
@@ -71,10 +90,10 @@ class ReadBlock:
         else:
             data = self._data
 
-        return data
+        return typing.cast("ByteArray1D", data)
 
     @property
-    def cached_data(self):
+    def cached_data(self) -> ByteArray1D:
         """
         Return cached data for an ASDF block.
 
@@ -87,7 +106,7 @@ class ReadBlock:
         return self._cached_data
 
     @property
-    def header(self):
+    def header(self) -> BlockHeader:
         """
         Get the block header. For a lazy loaded block the first time
         this is called the header will be read from the file and
@@ -100,10 +119,16 @@ class ReadBlock:
         """
         if not self.loaded:
             self.load()
-        return self._header
+        return typing.cast("BlockHeader", self._header)
 
 
-def _read_blocks_serially(fd, memmap=False, lazy_load=False, validate_checksums=False, after_magic=False):
+def _read_blocks_serially(
+    fd: GenericFile,
+    memmap: bool = False,
+    lazy_load: bool = False,
+    validate_checksums: bool = False,
+    after_magic: bool = False,
+) -> list[ReadBlock]:
     """
     Read blocks serially from a file without looking for a block index.
 
@@ -149,7 +174,13 @@ def _read_blocks_serially(fd, memmap=False, lazy_load=False, validate_checksums=
     return blocks
 
 
-def read_blocks(fd, memmap=False, lazy_load=False, validate_checksums=False, after_magic=False):
+def read_blocks(
+    fd: GenericFile,
+    memmap: bool = False,
+    lazy_load: bool = False,
+    validate_checksums: bool = False,
+    after_magic: bool = False,
+) -> list[ReadBlock]:
     """
     Read a sequence of ASDF blocks from a file.
 

--- a/asdf/_block/reader.py
+++ b/asdf/_block/reader.py
@@ -252,18 +252,19 @@ def read_blocks(
     # skip magic for each block
     magic_len = len(constants.BLOCK_MAGIC)
     blocks = [ReadBlock(offset + magic_len, fd, memmap, lazy_load, validate_checksums) for offset in block_index]
-    try:
-        # load first and last blocks to check if the index looks correct
-        for index in (0, -1):
+
+    # load first and last blocks to check if the index looks correct
+    for index in (0, -1):
+        try:
             fd.seek(block_index[index])
             buff = fd.read(magic_len)
             if buff != constants.BLOCK_MAGIC:
                 msg = "Invalid block magic"
                 raise OSError(msg)
             blocks[index].load()
-    except (OSError, ValueError) as e:
-        msg = f"Invalid block index contents for block {index}, falling back to serial reading: {e!s}"
-        warnings.warn(msg, AsdfBlockIndexWarning)
-        fd.seek(starting_offset)
-        return _read_blocks_serially(fd, memmap, lazy_load, after_magic)
+        except (OSError, ValueError) as e:
+            msg = f"Invalid block index contents for block {index}, falling back to serial reading: {e!s}"
+            warnings.warn(msg, AsdfBlockIndexWarning)
+            fd.seek(starting_offset)
+            return _read_blocks_serially(fd, memmap, lazy_load, after_magic)
     return blocks

--- a/asdf/_block/store.py
+++ b/asdf/_block/store.py
@@ -1,4 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
 from .key import Key
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 class Store:
@@ -12,12 +19,12 @@ class Store:
 
     def __init__(self):
         # store contains 2 layers of lookup: id(obj), Key
-        self._by_id = {}
+        self._by_id: dict[int, dict[Key, Any]] = {}
 
-    def lookup_by_object(self, obj, default=None):
+    def lookup_by_object(self, obj: Any, default: Any | None = None) -> Any | None:
         if isinstance(obj, Key):
             # if obj is a Key, look up the object
-            obj_id = id(obj._ref())
+            obj_id = id(obj._ref())  # pyrefly: ignore [not-callable]
             # and use the Key
             obj_key = obj
         else:
@@ -46,12 +53,12 @@ class Store:
         # no match, return default
         return default
 
-    def assign_object(self, obj, value):
+    def assign_object(self, obj: Any, value: Any) -> None:
         if isinstance(obj, Key):
             if not obj._is_valid():
                 msg = "Invalid key used for assign_object"
                 raise ValueError(msg)
-            obj_id = id(obj._ref())
+            obj_id = id(obj._ref())  # pyrefly: ignore [not-callable]
             obj_key = obj
         else:
             obj_id = id(obj)
@@ -79,13 +86,13 @@ class Store:
         # if no match was found, add using the key
         self._by_id[obj_id][obj_key] = value
 
-    def keys_for_value(self, value):
+    def keys_for_value(self, value: Any) -> Iterator[Key]:
         for oid, by_key in self._by_id.items():
             for key, stored_value in by_key.items():
                 if stored_value == value and key._is_valid():
                     yield key
 
-    def _cleanup(self, object_id=None):
+    def _cleanup(self, object_id: int | None = None) -> None:
         if object_id is None:
             for oid in set(self._by_id):
                 self._cleanup(oid)

--- a/asdf/_block/writer.py
+++ b/asdf/_block/writer.py
@@ -1,8 +1,19 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
 import numpy as np
 
 from asdf import constants
 
 from . import io as bio
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from asdf._block.io import BlockHeader
+    from asdf.generic_io import GenericFile
+    from asdf.typing import BlockDataCallback, ByteArray1D
 
 
 class WriteBlock:
@@ -10,13 +21,20 @@ class WriteBlock:
     Data and compression options needed to write an ASDF block.
     """
 
-    def __init__(self, data, compression=None, compression_kwargs=None):
+    _uri: str | None = None
+
+    def __init__(
+        self,
+        data: ByteArray1D | BlockDataCallback | None,
+        compression: str | None = None,
+        compression_kwargs: dict[str, Any] | None = None,
+    ):
         self._data = data
         self.compression = compression
         self.compression_kwargs = compression_kwargs
 
     @property
-    def data(self):
+    def data(self) -> ByteArray1D | None:
         if callable(self._data):
             return self._data()
         return self._data
@@ -29,7 +47,14 @@ class WriteBlock:
         return np.ndarray(0, np.uint8)
 
 
-def write_blocks(fd, blocks, padding=False, streamed_block=None, write_index=True, write_checksums=True):
+def write_blocks(
+    fd: GenericFile,
+    blocks: Sequence[WriteBlock],
+    padding: bool | float | None = False,
+    streamed_block: WriteBlock | None = None,
+    write_index: bool = True,
+    write_checksums: bool = True,
+) -> tuple[list[int | None], list[BlockHeader]]:
     """
     Write a list of WriteBlocks to a file
 
@@ -86,13 +111,13 @@ def write_blocks(fd, blocks, padding=False, streamed_block=None, write_index=Tru
     # to enable writing a block index for all valid files
     # we will wrap tell to return None on an error
 
-    def tell():
+    def tell() -> int | None:
         try:
             return fd.tell()
         except OSError:
             return None
 
-    offsets = []
+    offsets: list[int | None] = []
     headers = []
     for blk in blocks:
         offsets.append(tell())

--- a/asdf/_block/writer.py
+++ b/asdf/_block/writer.py
@@ -30,8 +30,8 @@ class WriteBlock:
         compression_kwargs: dict[str, Any] | None = None,
     ):
         self._data = data
-        self.compression = compression
-        self.compression_kwargs = compression_kwargs
+        self.compression: Compression = compression
+        self.compression_kwargs: dict[str, Any] | None = compression_kwargs
 
     @property
     def data(self) -> ByteArray1D | None:
@@ -40,7 +40,7 @@ class WriteBlock:
         return self._data
 
     @property
-    def data_bytes(self):
+    def data_bytes(self) -> ByteArray1D:
         data = self.data
         if data is not None:
             return np.ndarray(-1, np.uint8, data.ravel(order="K").data)

--- a/asdf/_block/writer.py
+++ b/asdf/_block/writer.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
     from asdf._block.io import BlockHeader
     from asdf.generic_io import GenericFile
-    from asdf.typing import BlockDataCallback, ByteArray1D
+    from asdf.typing import BlockDataCallback, ByteArray1D, Compression
 
 
 class WriteBlock:
@@ -26,7 +26,7 @@ class WriteBlock:
     def __init__(
         self,
         data: ByteArray1D | BlockDataCallback | None,
-        compression: str | None = None,
+        compression: Compression = None,
         compression_kwargs: dict[str, Any] | None = None,
     ):
         self._data = data

--- a/asdf/_commands/diff.py
+++ b/asdf/_commands/diff.py
@@ -328,6 +328,8 @@ def both_are_ndarrays(tree0, tree1):
     """Returns True if both inputs correspond to ndarrays, False otherwise"""
     if not (isinstance(tree0, Tagged) and isinstance(tree1, Tagged)):
         return False
+    if tree0._tag is None or tree1._tag is None:
+        return False
     if not (NDARRAY_TAG in tree0._tag and NDARRAY_TAG in tree1._tag):
         return False
     return True

--- a/asdf/_commands/edit.py
+++ b/asdf/_commands/edit.py
@@ -164,7 +164,7 @@ def write_edited_yaml_larger(path, new_content, version):
                 # update index
                 if block_index is not None:
                     offset = new_first_block_offset - old_first_block_offset
-                    updated_block_index = [i + offset for i in block_index]
+                    updated_block_index = [i + offset if i is not None else None for i in block_index]
                     bio.write_block_index(fd, updated_block_index)
 
         # Swap in the new version of the file atomically:

--- a/asdf/_compression.py
+++ b/asdf/_compression.py
@@ -1,12 +1,22 @@
+from __future__ import annotations
+
 import bz2
 import struct
+import typing
 import warnings
 import zlib
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
 from .config import get_config
 from .exceptions import AsdfWarning
+
+if TYPE_CHECKING:
+    from io import IOBase
+
+    from asdf.generic_io import GenericFile
+    from asdf.typing import ByteArray1D
 
 
 def validate(compression: str | bytes | None) -> str | None:
@@ -205,7 +215,7 @@ def _get_all_compression_extension_labels():
     return labels
 
 
-def _get_compressor(label):
+def _get_compressor(label: str) -> Any:
     ext_comp = _get_compressor_from_extensions(label)
 
     if ext_comp is not None:
@@ -238,7 +248,9 @@ def to_compression_header(compression):
     return compression
 
 
-def decompress(fd, used_size, data_size, compression, config=None):
+def decompress(
+    fd: GenericFile, used_size: int, data_size: int, compression: str, config: dict[Any, Any] | None = None
+) -> ByteArray1D:
     """
     Decompress binary data in a file
 
@@ -267,7 +279,7 @@ def decompress(fd, used_size, data_size, compression, config=None):
     """
     buffer = np.empty((data_size,), np.uint8)
 
-    compression = validate(compression)
+    compression = typing.cast("str", validate(compression))
     decoder = _get_compressor(compression)
     if config is None:
         config = {}
@@ -282,7 +294,12 @@ def decompress(fd, used_size, data_size, compression, config=None):
     return buffer
 
 
-def compress(fd, data, compression, config=None):
+def compress(
+    fd: GenericFile | IOBase,
+    data: ByteArray1D | bytes | bytearray,
+    compression: str | bytes,
+    config: dict[str, Any] | None = None,
+) -> None:
     """
     Compress array data and write to a file.
 
@@ -301,7 +318,7 @@ def compress(fd, data, compression, config=None):
         Any kwarg parameters to pass to the underlying compression
         function
     """
-    compression = validate(compression)
+    compression = typing.cast("str", validate(compression))
     encoder = _get_compressor(compression)
     if config is None:
         config = {}
@@ -311,17 +328,17 @@ def compress(fd, data, compression, config=None):
     # - 1D: so that len(data) works, not just data.nbytes
     # - itemsize: should preserve data.itemsize for compressors that want to use the record size
     # - memoryview: don't incur the expense of a memcpy, such as with tobytes()
-    data = memoryview(data)
-    if not data.contiguous:
-        data = memoryview(data.tobytes())  # make a contiguous copy
+    view = memoryview(data)  # pyrefly: ignore[bad-argument-type]
+    if not view.contiguous:
+        view = memoryview(view.tobytes())  # make a contiguous copy
 
     # get a 1D array that preserves byteorder
     # Note: in Python < 3.12 numpy typing doesn't correctly reflect that arrays support buffer protocol
     # See also: https://github.com/numpy/numpy/issues/26783
-    data = memoryview(np.frombuffer(data, dtype=data.format))  # pyrefly: ignore[bad-argument-type]
-    if not data.contiguous:
+    view = memoryview(np.frombuffer(view, dtype=view.format))  # pyrefly: ignore[bad-argument-type]
+    if not view.contiguous:
         # the data will be contiguous by construction, but better safe than sorry!
-        raise ValueError(data.contiguous)
+        raise ValueError(view.contiguous)
 
     compressed = encoder.compress(data, **config)
     # Write block by block
@@ -329,7 +346,9 @@ def compress(fd, data, compression, config=None):
         fd.write(comp)
 
 
-def get_compressed_size(data, compression, config=None):
+def get_compressed_size(
+    data: ByteArray1D | bytes | bytearray, compression: str, config: dict[str, Any] | None = None
+) -> int:
     """
     Returns the number of bytes required when the given data is
     compressed.
@@ -353,6 +372,6 @@ def get_compressed_size(data, compression, config=None):
             self.count += len(data)
 
     bcf = _ByteCountingFile()
-    compress(bcf, data, compression, config=config)
+    compress(bcf, data, compression, config=config)  # pyrefly: ignore [bad-argument-type]
 
     return bcf.count

--- a/asdf/_compression.py
+++ b/asdf/_compression.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from io import IOBase
 
     from asdf.generic_io import GenericFile
-    from asdf.typing import ByteArray1D
+    from asdf.typing import ByteArray1D, Compression
 
 
 def validate(compression: str | bytes | None) -> str | None:
@@ -234,7 +234,7 @@ def _get_compressor(label: str) -> Any:
     return comp
 
 
-def to_compression_header(compression):
+def to_compression_header(compression: Compression) -> bytes:
     """
     Converts a compression string to the four byte field in a block
     header.

--- a/asdf/_io.py
+++ b/asdf/_io.py
@@ -97,10 +97,10 @@ def read_comment_section(fd: GenericFile) -> list[bytes]:
 
 
 # Required for type narrowing in `find_asdf_version_in_comments``
-MaybeVer = TypeVar("MaybeVer", AsdfVersion, None)
+_MaybeVer = TypeVar("_MaybeVer", AsdfVersion, None)
 
 
-def find_asdf_version_in_comments(comments: list[bytes], default: MaybeVer = None) -> MaybeVer:
+def find_asdf_version_in_comments(comments: list[bytes], default: _MaybeVer = None) -> _MaybeVer:
     for comment in comments:
         parts = comment.split()
         if len(parts) == 2 and parts[0] == constants.ASDF_STANDARD_COMMENT:

--- a/asdf/_io.py
+++ b/asdf/_io.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import contextlib
 import io
 import pathlib
-from typing import TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from asdf.versioning import AsdfVersion
 
@@ -16,8 +16,15 @@ from ._block.manager import Manager as BlockManager
 from .exceptions import DelimiterNotFoundError
 from .tags.core import Software
 
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
-def get_asdf_library_info():
+    from asdf.generic_io import GenericFile
+    from asdf.tagged import TaggedDict
+    from asdf.typing import FileLike, FileMode, TreeKey
+
+
+def get_asdf_library_info() -> Software:
     """
     Get information about asdf to include in the asdf_library entry
     in the Tree.
@@ -64,7 +71,7 @@ def read_header_line(gf):
     return parse_header_line(header_line)
 
 
-def read_comment_section(fd):
+def read_comment_section(fd: GenericFile) -> list[bytes]:
     """
     Reads the comment section, between the header line and the
     Tree or first block.
@@ -93,7 +100,7 @@ def read_comment_section(fd):
 MaybeVer = TypeVar("MaybeVer", AsdfVersion, None)
 
 
-def find_asdf_version_in_comments(comments: list[str], default: MaybeVer = None) -> MaybeVer:
+def find_asdf_version_in_comments(comments: list[bytes], default: MaybeVer = None) -> MaybeVer:
     for comment in comments:
         parts = comment.split()
         if len(parts) == 2 and parts[0] == constants.ASDF_STANDARD_COMMENT:
@@ -108,7 +115,7 @@ def find_asdf_version_in_comments(comments: list[str], default: MaybeVer = None)
 
 
 @contextlib.contextmanager
-def maybe_close(fd, mode=None, uri=None):
+def maybe_close(fd: FileLike, mode: FileMode | None = None, uri: str | None = None) -> Generator[GenericFile]:
     if mode not in [None, "r", "rw"]:
         msg = f"Unrecognized asdf mode '{mode}'. Must be either 'r' or 'rw'"
         raise ValueError(msg)
@@ -133,7 +140,9 @@ def maybe_close(fd, mode=None, uri=None):
         yield generic_io.get_file(fd, mode=mode, uri=uri)
 
 
-def read_tree_and_blocks(gf, lazy_load, memmap, validate_checksums):
+def read_tree_and_blocks(
+    gf: GenericFile, lazy_load: bool, memmap: bool, validate_checksums: bool
+) -> tuple[TaggedDict[TreeKey, Any] | None, BlockManager]:
     token = gf.read(4)
     tree = None
     blocks = BlockManager(uri=gf.uri, lazy_load=lazy_load, memmap=memmap, validate_checksums=validate_checksums)
@@ -156,7 +165,14 @@ def read_tree_and_blocks(gf, lazy_load, memmap, validate_checksums):
     return tree, blocks
 
 
-def open_asdf(fd, uri=None, mode=None, lazy_load=True, memmap=False, validate_checksums=False):
+def open_asdf(
+    fd: FileLike,
+    uri: str | None = None,
+    mode: FileMode | None = None,
+    lazy_load: bool = True,
+    memmap: bool = False,
+    validate_checksums: bool = False,
+) -> tuple[AsdfVersion, list[bytes], TaggedDict[TreeKey, Any] | None, BlockManager]:
     with maybe_close(fd, mode, uri) as generic_file:
         file_format_version = read_header_line(generic_file)
         comments = read_comment_section(generic_file)

--- a/asdf/_tests/_block/test_callback.py
+++ b/asdf/_tests/_block/test_callback.py
@@ -11,6 +11,7 @@ def test_default_attribute():
         def __init__(self, value):
             self.data = value
 
+    # pyrefly: ignore [no-matching-overload]
     blks = ReadBlocks([Data("a"), Data("b")])
     cbs = [DataCallback(0, blks), DataCallback(1, blks)]
 
@@ -23,6 +24,7 @@ def test_attribute_access():
         def __init__(self, attr, value):
             setattr(self, attr, value)
 
+    # pyrefly: ignore [no-matching-overload]
     blks = ReadBlocks([Foo("a", "foo"), Foo("a", "bar")])
     cb = DataCallback(0, blks)
 
@@ -34,6 +36,7 @@ def test_weakref():
         def __init__(self, value):
             self.data = value
 
+    # pyrefly: ignore [no-matching-overload]
     blks = ReadBlocks([Data("a"), Data("b")])
     cb = DataCallback(0, blks)
     del blks
@@ -48,11 +51,13 @@ def test_reassign():
         def __init__(self, value):
             self.data = value
 
+    # pyrefly: ignore [no-matching-overload]
     blks = ReadBlocks([Data("a"), Data("b")])
     cb = DataCallback(0, blks)
 
     assert cb() == "a"
 
+    # pyrefly: ignore [no-matching-overload]
     blks2 = ReadBlocks([Data("c"), Data("d")])
     cb._reassign(1, blks2)
 

--- a/asdf/_tests/_block/test_external.py
+++ b/asdf/_tests/_block/test_external.py
@@ -15,8 +15,8 @@ def test_cache(tmp_path):
     data = cache.load(base_uri, "test.asdf")
     np.testing.assert_array_equal(data, arr)
     assert cache.load(base_uri, "test.asdf") is data
-    assert cache.load(base_uri, "#") is external.UseInternal
-    assert cache.load(base_uri, "") is external.UseInternal
+    assert cache.load(base_uri, "#") is external.USE_INTERNAL
+    assert cache.load(base_uri, "") is external.USE_INTERNAL
 
 
 @pytest.mark.parametrize("uri", ["test.asdf", "foo/test.asdf"])

--- a/asdf/_tests/_block/test_external.py
+++ b/asdf/_tests/_block/test_external.py
@@ -24,3 +24,7 @@ def test_cache(tmp_path):
 def test_relative_uri_for_index(uri, index):
     match = f"test{index:04d}.asdf"
     assert external.relative_uri_for_index(uri, index) == match
+
+
+def test_use_internal():
+    assert repr(external.USE_INTERNAL) == "UseInternal"

--- a/asdf/_tests/_block/test_io.py
+++ b/asdf/_tests/_block/test_io.py
@@ -12,7 +12,9 @@ from asdf._block.exceptions import BlockIndexError
 def test_checksum(tmp_path):
     my_array = np.arange(0, 64, dtype="<i8")
     target_checksum = b"\xcaM\\\xb8t_L|\x00\n+\x01\xf1\xcfP1"
+    # pyrefly: ignore [bad-argument-type]
     assert bio.calculate_block_checksum(my_array) == target_checksum
+    # pyrefly: ignore [bad-argument-type]
     assert bio.calculate_block_checksum(my_array.reshape((8, 8))) == target_checksum
 
     # check that when written, a block generates the correct checksum
@@ -144,9 +146,10 @@ def test_write_block(tmp_path):
     )
 
     # first write out a file with a block
-    my_array = np.array([], dtype="uint8")
+    my_array = np.array([], dtype=np.uint8)
     path = tmp_path / "test"
     with generic_io.get_file(path, mode="w") as fd:
+        # pyrefly: ignore [bad-argument-type]
         bio.write_block(fd, my_array)
 
     with generic_io.get_file(path, mode="r") as fd:

--- a/asdf/_tests/_block/test_reader.py
+++ b/asdf/_tests/_block/test_reader.py
@@ -42,7 +42,12 @@ def gen_blocks(
             fd.write(constants.BLOCK_MAGIC)
             data = np.ones(size, dtype="uint8") * i
             bio.write_block(
-                fd, data, stream=streamed and (i == n - 1), padding=block_padding, write_checksum=write_checksums
+                fd,
+                # pyrefly: ignore [bad-argument-type]
+                data,
+                stream=streamed and (i == n - 1),
+                padding=block_padding,
+                write_checksum=write_checksums,
             )
         if with_index and not streamed:
             bio.write_block_index(fd, offsets)
@@ -172,6 +177,8 @@ def test_invalid_block_in_index_with_valid_magic(tmp_path):
         # move the first block offset to the padding before
         # the second block with enough space to write
         # valid magic (but invalid header)
+
+        # pyrefly: ignore [unsupported-operation]
         block_index[0] = block_index[1] - 6
         fd.seek(block_index[0])
         fd.write(constants.BLOCK_MAGIC)

--- a/asdf/_tests/_block/test_store.py
+++ b/asdf/_tests/_block/test_store.py
@@ -172,6 +172,7 @@ def test_keys_for_value():
         returned_objects = set()
         for k in s.keys_for_value(v):
             assert k._is_valid()
+            # pyrefly: ignore [not-callable]
             obj = k._ref()
             returned_objects.add(obj)
         assert objs == returned_objects

--- a/asdf/_tests/_block/test_writer.py
+++ b/asdf/_tests/_block/test_writer.py
@@ -47,7 +47,7 @@ def test_write_blocks(tmp_path, lazy, index, padding, compression, stream, seeka
                 assert r.header["compression"] == compression
             if padding:
                 assert r.header["allocated_size"] > r.header["used_size"]
-        if stream:
+        if streamed_block is not None:
             read_stream_block = read_blocks[-1]
             np.testing.assert_array_equal(read_stream_block.data, streamed_block.data)
             assert read_stream_block.header["flags"] & constants.BLOCK_FLAG_STREAMED
@@ -79,7 +79,7 @@ def test_non_seekable_files_with_odd_tells(tmp_path, stream, index, tell):
     with generic_io.get_file(fn, mode="w") as fd:
         fd.seekable = lambda: False
         if callable(tell):
-            fd.tell = tell
+            fd.tell = tell  # pyrefly: ignore [bad-assignment]
         else:
             fd.tell = lambda: tell
         writer.write_blocks(fd, blocks, streamed_block=streamed_block, write_index=index)
@@ -96,7 +96,7 @@ def test_non_seekable_files_with_odd_tells(tmp_path, stream, index, tell):
                 assert r.data.size == 0
             else:
                 np.testing.assert_array_equal(r.data, d)
-        if stream:
+        if streamed_block is not None:
             read_stream_block = read_blocks[-1]
             np.testing.assert_array_equal(read_stream_block.data, streamed_block.data)
             assert read_stream_block.header["flags"] & constants.BLOCK_FLAG_STREAMED

--- a/asdf/_tests/_block/test_writer.py
+++ b/asdf/_tests/_block/test_writer.py
@@ -47,7 +47,9 @@ def test_write_blocks(tmp_path, lazy, index, padding, compression, stream, seeka
                 assert r.header["compression"] == compression
             if padding:
                 assert r.header["allocated_size"] > r.header["used_size"]
-        if streamed_block is not None:
+        if stream:
+            assert streamed_block is not None
+
             read_stream_block = read_blocks[-1]
             np.testing.assert_array_equal(read_stream_block.data, streamed_block.data)
             assert read_stream_block.header["flags"] & constants.BLOCK_FLAG_STREAMED

--- a/asdf/_tests/commands/test_edit.py
+++ b/asdf/_tests/commands/test_edit.py
@@ -7,6 +7,8 @@ import pytest
 from numpy.testing import assert_array_equal
 
 import asdf
+import asdf.generic_io
+import asdf.versioning
 from asdf import constants
 from asdf._block import io as bio
 from asdf._commands import main
@@ -163,6 +165,7 @@ def confirm_valid_block_index(file_path):
         assert block_index_offset is not None
         block_index = bio.read_block_index(f, block_index_offset)
         for block_offset in block_index:
+            assert block_offset is not None
             f.seek(block_offset)
             assert f.read(len(constants.BLOCK_MAGIC)) == constants.BLOCK_MAGIC
 

--- a/asdf/_tests/test_array_blocks.py
+++ b/asdf/_tests/test_array_blocks.py
@@ -728,6 +728,7 @@ def test_invalid_block_index_values():
     ff.write_to(buff, include_block_index=True)
     buff.seek(0)
     offset = bio.find_block_index(buff)
+    assert offset is not None, "Failed to find block index"
     buff.seek(offset)
     block_index = bio.read_block_index(buff)
     block_index.append(123456789)
@@ -804,6 +805,7 @@ def test_unordered_block_index():
     ff.write_to(buff, include_block_index=True)
     buff.seek(0)
     offset = bio.find_block_index(buff)
+    assert offset is not None, "Failed to find block index"
     buff.seek(offset)
     block_index = bio.read_block_index(buff)
     buff.seek(offset)

--- a/asdf/_tests/test_compression.py
+++ b/asdf/_tests/test_compression.py
@@ -1,6 +1,7 @@
 import io
 import lzma
 import os
+import typing
 from typing import Any
 
 import numpy as np
@@ -10,6 +11,9 @@ import asdf
 from asdf import _compression, config_context, generic_io
 from asdf._tests import _helpers as helpers
 from asdf.extension import Compressor, Extension
+
+if typing.TYPE_CHECKING:
+    from asdf.generic_io import GenericFile
 
 RNG = np.random.default_rng(0)
 
@@ -88,11 +92,12 @@ def test_get_compressed_size():
 
 
 def test_decompress_too_long_short():
-    fio = io.BytesIO()
+    fio = typing.cast("GenericFile", io.BytesIO())
     _compression.compress(fio, b"0" * 1024, "zlib")
     size = fio.tell()
     fio.seek(0)
     blocks = lambda us: [fio.read(us)]  # noqa: E731
+    # pyrefly: ignore [bad-assignment]
     fio.read_blocks = blocks
     _compression.decompress(fio, size, 1024, "zlib")
     fio.seek(0)
@@ -188,6 +193,7 @@ def test_set_array_compression(tmp_path):
             af_out.write_to(tmpfile)
         af_out.set_array_compression(bzp2_data, "bzp2", compresslevel=9)
         af_out.write_to(tmpfile)
+        # pyrefly: ignore [unsupported-operation]
         assert af_out.get_array_compression_kwargs(bzp2_data)["compresslevel"] == 9
 
     with asdf.open(tmpfile) as af_in:

--- a/asdf/generic_io.py
+++ b/asdf/generic_io.py
@@ -28,9 +28,11 @@ from .exceptions import DelimiterNotFoundError
 from .util import _patched_urllib_parse
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from fsspec.core import OpenFile
 
-    from asdf.typing import FileLike, FileMode, PathLike
+    from asdf.typing import ByteArray1D, FileLike, FileMode, Reader
 
 __all__ = ["GenericFile", "get_file", "get_uri", "relative_uri", "resolve_uri"]
 
@@ -71,7 +73,7 @@ def _check_bytes(fd, mode):
     return True
 
 
-def resolve_uri(base, uri):
+def resolve_uri(base: str | None, uri: str) -> str:
     """
     Resolve a URI against a base URI.
     """
@@ -85,7 +87,7 @@ def resolve_uri(base, uri):
     return resolved
 
 
-def relative_uri(source, target):
+def relative_uri(source: str, target: str) -> str:
     """
     Make a relative URI from source to target.
     """
@@ -206,7 +208,7 @@ class GenericFile(metaclass=util._InheritDocstrings):
     subclass for the given file-like object.
     """
 
-    def __init__(self, fd, mode, close=False, uri=None):
+    def __init__(self, fd, mode: FileMode, close: bool = False, uri: str | None = None):
         """
         Parameters
         ----------
@@ -245,10 +247,10 @@ class GenericFile(metaclass=util._InheritDocstrings):
 
         self.block_size = get_config().io_block_size
 
-    def __enter__(self):
+    def __enter__(self) -> GenericFile:
         return self
 
-    def __exit__(self, type_, value, traceback):
+    def __exit__(self, type_, value, traceback) -> None:
         if self._close:
             if hasattr(self._fd, "__exit__"):
                 self._fd.__exit__(type_, value, traceback)
@@ -274,20 +276,20 @@ class GenericFile(metaclass=util._InheritDocstrings):
         self._blksize = block_size
 
     @property
-    def mode(self):
+    def mode(self) -> FileMode:
         """
         The mode of the file.  Will be ``'r'``, ``'w'`` or ``'rw'``.
         """
         return self._mode
 
     @property
-    def uri(self):
+    def uri(self) -> str | None:
         """
         The base uri of the file.
         """
         return self._uri
 
-    def read(self, size=-1):
+    def read(self, size: int = -1) -> bytes:
         """
         Read at most size bytes from the file (less if the read hits
         EOF before obtaining size bytes). If the size argument is
@@ -303,14 +305,14 @@ class GenericFile(metaclass=util._InheritDocstrings):
             return b""
         return self._fd.read(size)
 
-    def read_block(self):
+    def read_block(self) -> bytes:
         """
         Read a "block" from the file.  For real filesystem files, the
         block is the size of a native filesystem block.
         """
         return self.read(self._blksize)
 
-    def read_blocks(self, size):
+    def read_blocks(self, size: int) -> Iterator[bytes]:
         """
         Read ``size`` bytes of data from the file, one block at a
         time.  The result is a generator where each value is a bytes
@@ -320,7 +322,7 @@ class GenericFile(metaclass=util._InheritDocstrings):
             thissize = min(self._blksize, size - i)
             yield self.read(thissize)
 
-    def write(self, content):
+    def write(self, content: bytes | bytearray | memoryview) -> None:
         self._fd.write(content)
 
     write.__doc__ = """
@@ -331,7 +333,7 @@ class GenericFile(metaclass=util._InheritDocstrings):
     Only available if `writable` returns `True`.
     """
 
-    def write_array(self, array):
+    def write_array(self, array: ByteArray1D) -> None:
         """
         Write array content to the file.  Array must be 1D contiguous
         so that this method can avoid making assumptions about the
@@ -348,7 +350,7 @@ class GenericFile(metaclass=util._InheritDocstrings):
 
         self.write(array.data)
 
-    def peek(self, size=-1):
+    def peek(self, size: int = -1) -> bytes:
         """
         Read bytes of the file without consuming them.  This method
         must be implemented by all GenericFile implementations that
@@ -370,7 +372,7 @@ class GenericFile(metaclass=util._InheritDocstrings):
         msg = "Non-seekable file"
         raise RuntimeError(msg)
 
-    def seek(self, offset, whence=0):
+    def seek(self, offset: int, whence: int = 0) -> int:
         """
         Set the file's current position.  Only available if `seekable`
         returns `True`.
@@ -390,20 +392,20 @@ class GenericFile(metaclass=util._InheritDocstrings):
         result = self._fd.seek(offset, whence)
         return result
 
-    def tell(self):
+    def tell(self) -> int:
         """
         Return the file's current position, in bytes.  Only available
         in `seekable` returns `True`.
         """
         return self._fd.tell()
 
-    def flush(self):
+    def flush(self) -> None:
         """
         Flush the internal buffer.
         """
         self._fd.flush()
 
-    def close(self):
+    def close(self) -> None:
         """
         Close the file.  The underlying file-object will only be
         closed if ``close=True`` was passed to the constructor.
@@ -413,38 +415,38 @@ class GenericFile(metaclass=util._InheritDocstrings):
             if hasattr(self, "_fix_permissions"):
                 self._fix_permissions()
 
-    def truncate(self, size=None):
+    def truncate(self, size: int | None = None) -> None:
         """
         Truncate the file to the given size.
         """
         raise NotImplementedError
 
-    def writable(self):
+    def writable(self) -> bool:
         """
         Returns `True` if the file can be written to.
         """
         return "w" in self.mode
 
-    def readable(self):
+    def readable(self) -> bool:
         """
         Returns `True` if the file can be read from.
         """
         return "r" in self.mode
 
-    def seekable(self):
+    def seekable(self) -> bool:
         """
         Returns `True` if the file supports random access (`seek` and
         `tell`).
         """
         return False
 
-    def can_memmap(self):
+    def can_memmap(self) -> bool:
         """
         Returns `True` if the file supports memmapping.
         """
         return False
 
-    def is_closed(self):
+    def is_closed(self) -> bool:
         """
         Returns `True` if the underlying file object is closed.
         """
@@ -452,13 +454,13 @@ class GenericFile(metaclass=util._InheritDocstrings):
 
     def read_until(
         self,
-        delimiter,
-        readahead_bytes,
-        delimiter_name=None,
-        include=True,
-        initial_content=b"",
-        exception=True,
-    ):
+        delimiter: str | bytes,
+        readahead_bytes: int,
+        delimiter_name: str | None = None,
+        include: bool = True,
+        initial_content: bytes = b"",
+        exception: bool = True,
+    ) -> bytes:
         """
         Reads until a match for a given regular expression is found.
 
@@ -517,13 +519,13 @@ class GenericFile(metaclass=util._InheritDocstrings):
 
     def reader_until(
         self,
-        delimiter,
-        readahead_bytes,
-        delimiter_name=None,
-        include=True,
-        initial_content=b"",
-        exception=True,
-    ):
+        delimiter: str | bytes,
+        readahead_bytes: int,
+        delimiter_name: str | None = None,
+        include: bool = True,
+        initial_content: bytes = b"",
+        exception: bool = True,
+    ) -> Reader:
         """
         Returns a readable file-like object that treats the given
         delimiter as the end-of-file.
@@ -562,13 +564,13 @@ class GenericFile(metaclass=util._InheritDocstrings):
 
     def seek_until(
         self,
-        delimiter,
-        readahead_bytes,
-        delimiter_name=None,
-        include=True,
-        initial_content=b"",
-        exception=True,
-    ):
+        delimiter: str | bytes,
+        readahead_bytes: int,
+        delimiter_name: str | None = None,
+        include: bool = True,
+        initial_content: bytes = b"",
+        exception: bool = True,
+    ) -> bool:
         """
         Seeks in the file until a match for a given regular expression
         is found.  This is similar to ``read_until``, except the
@@ -629,13 +631,13 @@ class GenericFile(metaclass=util._InheritDocstrings):
 
         return True
 
-    def fast_forward(self, size):
+    def fast_forward(self, size: int) -> None:
         """
         Move the file position forward by ``size``.
         """
         raise NotImplementedError
 
-    def clear(self, nbytes):
+    def clear(self, nbytes: int) -> None:
         """
         Write nbytes of zeros.
         """
@@ -644,7 +646,7 @@ class GenericFile(metaclass=util._InheritDocstrings):
             length = min(nbytes - i, self.block_size)
             self.write(blank_data[:length])
 
-    def memmap_array(self, offset, size):
+    def memmap_array(self, offset: int, size: int) -> np.memmap:
         """
         Memmap a chunk of the file into a ``np.memmap`` object.
 
@@ -663,14 +665,14 @@ class GenericFile(metaclass=util._InheritDocstrings):
         msg = f"memmapping is not implemented for {self.__class__.__name__}"
         raise NotImplementedError(msg)
 
-    def close_memmap(self):
+    def close_memmap(self) -> None:
         """
         Close the memmapped file (if one was mapped with memmap_array)
         """
         msg = f"memmapping is not implemented for {self.__class__.__name__}"
         raise NotImplementedError(msg)
 
-    def flush_memmap(self):
+    def flush_memmap(self) -> None:
         """
         Flush any pending writes to the memmapped file (if one was mapped with
         memmap_array)
@@ -678,7 +680,7 @@ class GenericFile(metaclass=util._InheritDocstrings):
         msg = f"memmapping is not implemented for {self.__class__.__name__}"
         raise NotImplementedError(msg)
 
-    def read_into_array(self, size):
+    def read_into_array(self, size: int) -> ByteArray1D:
         """
         Read a chunk of the file into a uint8 array.
 
@@ -692,7 +694,8 @@ class GenericFile(metaclass=util._InheritDocstrings):
         array : np.memmap
         """
         buff = self.read(size)
-        return np.frombuffer(buff, np.uint8, size, 0)
+        # Need cast because numpy doesn't type frombuffer as a 1D array
+        return typing.cast("ByteArray1D", np.frombuffer(buff, np.uint8, size, 0))
 
 
 class GenericWrapper:
@@ -719,11 +722,11 @@ class RandomAccessFile(GenericFile):
     The base class of file types that support random access.
     """
 
-    def __init__(self, fd, mode, close=False, uri=None, inner_fd=None):
+    def __init__(self, fd, mode: FileMode, close: bool = False, uri: str | None = None, inner_fd=None):
         super().__init__(fd, mode, close, uri)
         self._inner_fd = inner_fd
 
-    def seekable(self):
+    def seekable(self) -> bool:
         return True
 
     def reader_until(
@@ -745,12 +748,12 @@ class RandomAccessFile(GenericFile):
             exception=exception,
         )
 
-    def fast_forward(self, size):
+    def fast_forward(self, size: int) -> None:
         if size < 0:
             self.seek(0, SEEK_END)
         self.seek(size, SEEK_CUR)
 
-    def truncate(self, size=None):
+    def truncate(self, size: int | None = None) -> None:
         if size is None:
             self._fd.truncate()
         else:
@@ -763,7 +766,7 @@ class RealFile(RandomAccessFile):
     Handles "real" files on a filesystem.
     """
 
-    def __init__(self, fd, mode, close=False, uri=None, inner_fd=None):
+    def __init__(self, fd, mode: FileMode, close: bool = False, uri: str | None = None, inner_fd=None):
         super().__init__(fd, mode, close=close, uri=uri, inner_fd=inner_fd)
 
         if uri is None and hasattr(fd, "name") and isinstance(fd.name, str):
@@ -863,7 +866,7 @@ class MemoryIO(RandomAccessFile):
     `StringIO.StringIO`.
     """
 
-    def __init__(self, fd, mode, uri=None, inner_fd=None):
+    def __init__(self, fd, mode: FileMode, uri: str | None = None, inner_fd=None):
         super().__init__(fd, mode, uri=uri, inner_fd=inner_fd)
 
     def read_into_array(self, size):
@@ -881,7 +884,7 @@ class InputStream(GenericFile):
     Handles an input stream, such as stdin.
     """
 
-    def __init__(self, fd, mode="r", close=False, uri=None):
+    def __init__(self, fd, mode: FileMode = "r", close: bool = False, uri: str | None = None):
         super().__init__(fd, mode, close=close, uri=uri)
         self._fd = fd
         self._buffer = b""
@@ -972,7 +975,7 @@ class OutputStream(GenericFile):
     Handles an output stream, such as stdout.
     """
 
-    def __init__(self, fd, close=False, uri=None):
+    def __init__(self, fd, close: bool = False, uri: str | None = None):
         super().__init__(fd, "w", close=close, uri=uri)
         self._fd = fd
 
@@ -1002,7 +1005,7 @@ def get_uri(file_obj):
 def get_file(
     init: FileLike,
     mode: FileMode = "r",
-    uri: PathLike | None = None,
+    uri: str | None = None,
     close: bool = False,
 ) -> GenericFile:
     """
@@ -1124,7 +1127,7 @@ def get_file(
             except NotImplementedError as err:
                 msg = f"Unable to open {init} with mode {mode}"
                 raise ValueError(msg) from err
-            return get_file(fd, uri=uri or init, close=True)
+            return get_file(fd, uri=str(uri or init), close=True)
 
     if isinstance(init, io.BytesIO):
         return MemoryIO(init, mode, uri=uri)

--- a/asdf/tagged.py
+++ b/asdf/tagged.py
@@ -39,18 +39,18 @@ if TYPE_CHECKING:
 
 __all__ = ["Tagged", "TaggedDict", "TaggedList", "TaggedString", "get_tag", "tag_object"]
 
-T = TypeVar("T")
-K = TypeVar("K")
-V = TypeVar("V")
+_T = TypeVar("_T")
+_KT = TypeVar("_KT")
+_VT = TypeVar("_VT")
 
 
-class Tagged(Generic[T]):
+class Tagged(Generic[_T]):
     """
     Base class of classes that wrap a given object and store a tag
     with it.
     """
 
-    _base_type: type[T]
+    _base_type: type[_T]
     _tag: str | None = None
 
     @property
@@ -60,7 +60,7 @@ class Tagged(Generic[T]):
         return self._base_type(self)  # pyrefly: ignore [bad-argument-count]
 
 
-class TaggedDict(Generic[K, V], Tagged[dict[K, V]], UserDict[K, V], dict[K, V]):
+class TaggedDict(Generic[_KT, _VT], Tagged[dict[_KT, _VT]], UserDict[_KT, _VT], dict[_KT, _VT]):
     """
     A Python dict with a tag attached.
     """
@@ -88,7 +88,7 @@ class TaggedDict(Generic[K, V], Tagged[dict[K, V]], UserDict[K, V], dict[K, V]):
         return TaggedDict(data_copy, self._tag)
 
 
-class TaggedList(Generic[T], Tagged[list[T]], UserList[T], list[T]):
+class TaggedList(Generic[_T], Tagged[list[_T]], UserList[_T], list[_T]):
     """
     A Python list with a tag attached.
     """

--- a/asdf/tagged.py
+++ b/asdf/tagged.py
@@ -28,28 +28,39 @@ and dumper (``yamlutil.AsdfLoader`` and ``yamlutil.AsdfDumper``) and
 is not intended to be exposed to the end user.
 """
 
+from __future__ import annotations
+
 from collections import UserDict, UserList, UserString
 from copy import copy, deepcopy
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, overload
+
+if TYPE_CHECKING:
+    from asdf import AsdfFile
 
 __all__ = ["Tagged", "TaggedDict", "TaggedList", "TaggedString", "get_tag", "tag_object"]
 
+T = TypeVar("T")
+K = TypeVar("K")
+V = TypeVar("V")
 
-class Tagged:
+
+class Tagged(Generic[T]):
     """
     Base class of classes that wrap a given object and store a tag
     with it.
     """
 
-    _base_type = None
+    _base_type: type[T]
+    _tag: str | None = None
 
     @property
     def base(self):
         """Convert to base type"""
 
-        return self._base_type(self)
+        return self._base_type(self)  # pyrefly: ignore [bad-argument-count]
 
 
-class TaggedDict(Tagged, UserDict, dict):
+class TaggedDict(Generic[K, V], Tagged[dict[K, V]], UserDict[K, V], dict[K, V]):
     """
     A Python dict with a tag attached.
     """
@@ -77,7 +88,7 @@ class TaggedDict(Tagged, UserDict, dict):
         return TaggedDict(data_copy, self._tag)
 
 
-class TaggedList(Tagged, UserList, list):
+class TaggedList(Generic[T], Tagged[list[T]], UserList[T], list[T]):
     """
     A Python list with a tag attached.
     """
@@ -104,7 +115,7 @@ class TaggedList(Tagged, UserList, list):
         return TaggedList(data_copy, self._tag)
 
 
-class TaggedString(Tagged, UserString, str):
+class TaggedString(Tagged[str], UserString, str):
     """
     A Python string with a tag attached.
     """
@@ -113,8 +124,24 @@ class TaggedString(Tagged, UserString, str):
 
     style = None
 
-    def __eq__(self, other):
-        return isinstance(other, TaggedString) and str.__eq__(self, other) and self._tag == other._tag
+    def __eq__(self, string):
+        return isinstance(string, TaggedString) and str.__eq__(self, string) and self._tag == string._tag
+
+
+_Tagged = TypeVar("_Tagged", bound=Tagged)
+
+
+# Define specific overloads mapping types to their tagged versions
+@overload
+def tag_object(tag: str, instance: _Tagged, ctx: AsdfFile | None = ...) -> _Tagged: ...
+@overload
+def tag_object(tag: str, instance: dict[Any, Any], ctx: AsdfFile | None = ...) -> TaggedDict: ...
+@overload
+def tag_object(tag: str, instance: list[Any], ctx: AsdfFile | None = ...) -> TaggedList: ...
+@overload
+def tag_object(tag: str, instance: str, ctx: AsdfFile | None = ...) -> TaggedString: ...
+@overload
+def tag_object(tag: str, instance: Any, ctx: AsdfFile | None = ...) -> Tagged: ...
 
 
 def tag_object(tag, instance, ctx=None):
@@ -142,6 +169,12 @@ def tag_object(tag, instance, ctx=None):
             raise TypeError(msg) from err
         instance._tag = tag
     return instance
+
+
+@overload
+def get_tag(instance: Tagged) -> str: ...
+@overload
+def get_tag(instance: Any) -> None: ...
 
 
 def get_tag(instance):

--- a/asdf/typing.py
+++ b/asdf/typing.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any, AnyStr, Literal, Protocol, TypeAlias
 
+import numpy as np
 import numpy.typing as npt
 
 from asdf.generic_io import GenericFile
@@ -41,7 +42,7 @@ class ExtensionLike(Protocol):
 class Reader(Protocol[AnyStr]):  # pyrefly: ignore[variance-mismatch]
     """Object with a ``read`` method that returns string or bytes."""
 
-    def read(self, /) -> AnyStr: ...
+    def read(self, length: int = ..., /) -> AnyStr: ...
 
 
 class Writer(Protocol[AnyStr]):  # pyrefly: ignore[variance-mismatch]
@@ -81,3 +82,9 @@ FilterFn: TypeAlias = Callable[[Any], bool] | Callable[[Any, Any], bool]
 
 #: ASDF-compatible multi-dimensional array
 NDArray: TypeAlias = npt.NDArray[Any]
+
+#: A 1-D byte numpy array used to read and write block data
+ByteArray1D: TypeAlias = np.ndarray[tuple[int], np.dtype[np.uint8]]
+
+#: A callback that returns a `ByteArray1D`
+BlockDataCallback = Callable[[], ByteArray1D]

--- a/asdf/typing.py
+++ b/asdf/typing.py
@@ -15,6 +15,8 @@ from asdf.versioning import AsdfVersion
 __all__ = [
     "ArrayStorage",
     "AsdfVersionLike",
+    "BlockDataCallback",
+    "ByteArray1D",
     "Compression",
     "ExtensionLike",
     "FileLike",

--- a/asdf/typing.py
+++ b/asdf/typing.py
@@ -73,7 +73,7 @@ FileMode: TypeAlias = Literal["r", "w", "rw"]
 
 # TODO: find a way to represent this where it will accept arbitrary strings but still suggest the set of literals
 #: Supported compression types
-Compression: TypeAlias = Literal["zlib", "bzp2", "lz4", "input", ""] | str | None
+Compression: TypeAlias = Literal["zlib", "bzp2", "lz4", "input", ""] | str | bytes | None
 #: Supported array storage modes
 ArrayStorage: TypeAlias = Literal["internal", "external", "inline", "streamed"] | None
 

--- a/asdf/util.py
+++ b/asdf/util.py
@@ -128,7 +128,7 @@ def _iter_subclasses(cls):
         yield from _iter_subclasses(x)
 
 
-def calculate_padding(content_size, pad_blocks, block_size):
+def calculate_padding(content_size: int, pad_blocks: float | bool | None, block_size: int) -> int:
     """
     Calculates the amount of extra space to add to a block given the
     user's request for the amount of extra space.  Care is given so

--- a/asdf/yamlutil.py
+++ b/asdf/yamlutil.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 import warnings
 from collections import OrderedDict
 from types import GeneratorType
+from typing import TYPE_CHECKING
 
 import numpy as np
 import yaml
@@ -12,6 +15,12 @@ from .exceptions import AsdfConversionWarning, AsdfSerializationError
 from .extension._serialization_context import BlockAccess
 from .tags.core import AsdfObject
 from .versioning import _YAML_VERSION, _yaml_base_loader
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    from asdf.tagged import Tagged, TaggedDict
+    from asdf.typing import Reader, TreeKey
 
 __all__ = ["custom_tree_to_tagged_tree", "tagged_tree_to_custom_tree"]
 
@@ -234,7 +243,7 @@ AsdfLoader.add_constructor(None, AsdfLoader.construct_undefined)
 AsdfLoader.add_constructor(YAML_TAG_PREFIX + "omap", AsdfLoader.construct_yaml_omap)
 
 
-def custom_tree_to_tagged_tree(tree, ctx, _serialization_context=None):
+def custom_tree_to_tagged_tree(tree, ctx, _serialization_context=None) -> Tagged:
     """
     Convert a tree, possibly containing custom data types that aren't
     directly representable in YAML, to a tree of basic data types,
@@ -376,7 +385,7 @@ def tagged_tree_to_custom_tree(tree, ctx, force_raw_types=False, _serialization_
     )
 
 
-def load_tree(stream):
+def load_tree(stream: Reader) -> TaggedDict[TreeKey, Any]:
     """
     Load YAML, returning a tree of objects.
 

--- a/docs/asdf/user_api/asdf_typing.rst
+++ b/docs/asdf/user_api/asdf_typing.rst
@@ -5,4 +5,4 @@ asdf.typing Module
 .. automodapi:: asdf.typing
     :include-all-objects:
     :no-inheritance-diagram:
-    :skip: NDArray
+    :skip: NDArray, ByteArray1D, BlockDataCallback

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,6 +58,7 @@ nitpick_ignore = [
     ("py:attr", "asdf.util._NOT_SET_TYPE.NOT_SET"),
     # Needed because sphinx breaks trying to process `asdf.typing.NDArray` for some reason
     ("py:class", "NDArray"),
+    ("py:class", "ByteArray1D"),
     # Needed because `dict_keys` isn't documented
     ("py:class", "dict_keys"),
 ]


### PR DESCRIPTION
## Description
* `asdf._block` and its submodules now have 100% type coverage. 
* `GenericFile` and its subclasses are mostly fully typed now.
* The advantage of adding this type coverage is now its possible to trace the precise usage of `generic_io` classes in the rest of the codebase, which will aid in future refactors.
* Added new type aliases to `asdf.typing`:
  * `ByteArray1D` as an alias for a 1-D uint8 numpy array which is used all over the place in block IO
  * `BlockDataCallback` as an alias for a callable that returns `ByteArray1D`, which is used for lazy block loading 
* Added a `BlockHeader` typed dictionary to describe the block header fields
* The tagged container types are now generic in the same way as their parent types, e.g. you can now annotate a value with `TaggedDict[str, int]` or `TaggedList[float]`
* Similarly, `Tagged` is now also generic over its inner type, which means type checkers will now recognize `TaggedList[str]` as a subtype of `Tagged[list[str]]`.
* Converted `asdf._block.external.UseInternal` to be a sentinel value that type checkers will understand: the actual value has been renamed to `USE_INTERNAL` and `UseInternal` is now a type alias for the value's type.

As with the previous typing PR there should be no functional changes and no changes to the public API (other than adding type hints and the change to `UseInternal`, which I'm not sure is public).

I made a few refactoring changes when necessary. Most of them are downstream of the fact that `ReadBlock` and `WriteBlock` can have an offset of `None` if the source file isn't seekable (or if the file being read was not seekable when written). There are a lot of places that assume that offset is an integer and would break if offset were ever actually `None`, so I had to add some checks in those places to handle the `None` case. 
In the future I think that we should just drop support for non-seekable files, which would allow offset to always be an integer.