### PR TITLE
Remove `_InheritDocstrings`

### DIFF
--- a/asdf/generic_io.py
+++ b/asdf/generic_io.py
@@ -22,7 +22,6 @@ from urllib.request import url2pathname
 
 import numpy as np
 
-from . import util
 from ._extern import atomicfile
 from .exceptions import DelimiterNotFoundError
 from .util import _patched_urllib_parse
@@ -195,7 +194,7 @@ class _TruncatedReader:
         return content
 
 
-class GenericFile(metaclass=util._InheritDocstrings):
+class GenericFile:
     """
     Base class for an abstraction layer around a number of different
     file-like types.  Each of its subclasses handles a particular kind
@@ -321,15 +320,14 @@ class GenericFile(metaclass=util._InheritDocstrings):
             yield self.read(thissize)
 
     def write(self, content):
+        """
+        Write a string to the file. There is no return value. Due to
+        buffering, the string may not actually show up in the file
+        until the flush() or close() method is called.
+
+        Only available if `writable` returns `True`.
+        """
         self._fd.write(content)
-
-    write.__doc__ = """
-    Write a string to the file. There is no return value. Due to
-    buffering, the string may not actually show up in the file
-    until the flush() or close() method is called.
-
-    Only available if `writable` returns `True`.
-    """
 
     def write_array(self, array):
         """

--- a/asdf/util.py
+++ b/asdf/util.py
@@ -1,6 +1,5 @@
 import enum
 import importlib.util
-import inspect
 import math
 import re
 import struct
@@ -274,47 +273,6 @@ def get_class_name(obj, instance=True):
     """
     typ = type(obj) if instance else obj
     return f"{typ.__module__}.{typ.__qualname__}"
-
-
-class _InheritDocstrings(type):
-    """
-    This metaclass makes methods of a class automatically have their
-    docstrings filled in from the methods they override in the base
-    class.
-
-    If the class uses multiple inheritance, the docstring will be
-    chosen from the first class in the bases list, in the same way as
-    methods are normally resolved in Python.  If this results in
-    selecting the wrong docstring, the docstring will need to be
-    explicitly included on the method.
-
-    For example::
-
-        >>> from asdf.util import _InheritDocstrings
-        >>> class A(metaclass=_InheritDocstrings):
-        ...     def wiggle(self):
-        ...         "Wiggle the thingamajig"
-        ...         pass
-        >>> class B(A):
-        ...     def wiggle(self):
-        ...         pass
-        >>> B.wiggle.__doc__
-        'Wiggle the thingamajig'
-    """
-
-    def __init__(cls, name, bases, dct):
-        def is_public_member(key):
-            return (key.startswith("__") and key.endswith("__") and len(key) > 4) or not key.startswith("_")
-
-        for key, val in dct.items():
-            if inspect.isfunction(val) and is_public_member(key) and val.__doc__ is None:
-                for base in cls.__mro__[1:]:
-                    super_method = getattr(base, key, None)
-                    if super_method is not None:
-                        val.__doc__ = super_method.__doc__
-                        break
-
-        super().__init__(name, bases, dct)
 
 
 class _NOT_SET_TYPE(enum.Enum):


### PR DESCRIPTION
## Description
* Removed `_InheritDocstrings` metaclass

`_InheritDocstrings` seems unnecessary because its intended behavior is already built in to Sphinx (and other docs generators).
Additionally it will overwrite the docstring of a child method with the parent docstring even if the child is already documented, which doesn't seem like desired behavior.

This PR produces no changes in the public API documentation. 