### PR TITLE
Pin `globus-sdk` in dkist downstream CI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -317,6 +317,9 @@ commands_pre =
     bash -c "pip freeze -q | grep 'asdf @' > {env_tmp_dir}/asdf_requirement.txt"
     pip install -e ".[tests]"
     pip install -r {env_tmp_dir}/asdf_requirement.txt
+    # Pinned to work around upstream package incompatibility
+    # https://github.com/DKISTDC/dkist/issues/725
+    pip install "globus-sdk==4.5.0"
     pip freeze
 commands =
     pytest --benchmark-skip


### PR DESCRIPTION
## Description
* Updated `dkist` environment in `tox.ini` to pin `globus-sdk==4.5.0`

This change allows the `dkist` downstream CI job to pass.
See DKISTDC/dkist#725 for details.

Once `dkist` is updated to either pin `globus-sdk` itself or resolve the incompatibility with `>=4.6.0` this change can be reverted.