### PR TITLE
Change block index verification

### DIFF
--- a/asdf/_block/io.py
+++ b/asdf/_block/io.py
@@ -536,7 +536,7 @@ def find_block_index(fd: GenericFile, min_offset: int | None = None, max_offset:
     return block_index_offset
 
 
-def read_block_index(fd: GenericFile, offset: int | None = None) -> list[int | None]:
+def read_block_index(fd: GenericFile, offset: int | None = None) -> list[int]:
     """
     Read an ASDF block index from a file.
 

--- a/asdf/_block/reader.py
+++ b/asdf/_block/reader.py
@@ -232,7 +232,7 @@ def read_blocks(
         # load all blocks serially
         return _read_blocks_serially(fd, memmap, lazy_load, validate_checksums, after_magic)
 
-    # storet starting offset
+    # store starting offset
     starting_offset = fd.tell()
     magic_len = len(constants.BLOCK_MAGIC)
 

--- a/asdf/_block/reader.py
+++ b/asdf/_block/reader.py
@@ -278,4 +278,7 @@ def read_blocks(
         return _read_blocks_serially(fd, memmap, lazy_load, after_magic)
 
     # skip magic for each block
-    return [ReadBlock(offset + magic_len, fd, memmap, lazy_load, validate_checksums) for offset in block_index]
+    return [
+        ReadBlock(offset + magic_len if offset is not None else None, fd, memmap, lazy_load, validate_checksums)
+        for offset in block_index
+    ]

--- a/asdf/_block/reader.py
+++ b/asdf/_block/reader.py
@@ -232,8 +232,21 @@ def read_blocks(
         # load all blocks serially
         return _read_blocks_serially(fd, memmap, lazy_load, validate_checksums, after_magic)
 
-    # try to find block index
+    # storet starting offset
     starting_offset = fd.tell()
+    magic_len = len(constants.BLOCK_MAGIC)
+
+    # we should be at the first block, have no blocks, or have padding
+    if not after_magic:
+        # seek until the first magic is found
+        try:
+            fd.seek_until(b"(" + constants.BLOCK_MAGIC + b")", magic_len)
+        except DelimiterNotFoundError:
+            fd.seek(starting_offset)
+            return []
+    first_block_offset = fd.tell() - magic_len
+
+    # try to find block index
     index_offset = bio.find_block_index(fd, starting_offset)
     if index_offset is None:
         # if failed, load all blocks serially
@@ -249,25 +262,20 @@ def read_blocks(
         warnings.warn(msg, AsdfBlockIndexWarning)
         fd.seek(starting_offset)
         return _read_blocks_serially(fd, memmap, lazy_load, validate_checksums, after_magic)
-    # skip magic for each block
-    magic_len = len(constants.BLOCK_MAGIC)
-    blocks = [
-        ReadBlock(offset + magic_len if offset is not None else None, fd, memmap, lazy_load, validate_checksums)
-        for offset in block_index
-    ]
 
-    # load first and last blocks to check if the index looks correct
-    for index in (0, -1):
-        try:
-            fd.seek(typing.cast("int", block_index[index]))
-            buff = fd.read(magic_len)
-            if buff != constants.BLOCK_MAGIC:
-                msg = "Invalid block magic"
-                raise OSError(msg)
-            blocks[index].load()
-        except (OSError, ValueError) as e:
-            msg = f"Invalid block index contents for block {index}, falling back to serial reading: {e!s}"
-            warnings.warn(msg, AsdfBlockIndexWarning)
-            fd.seek(starting_offset)
-            return _read_blocks_serially(fd, memmap, lazy_load, after_magic)
-    return blocks
+    # index says no blocks but we found block magic above, this so the index is wrong
+    if not len(block_index):
+        msg = "Failed to read block index, falling back to serial reading"
+        warnings.warn(msg, AsdfBlockIndexWarning)
+        fd.seek(starting_offset)
+        return _read_blocks_serially(fd, memmap, lazy_load, validate_checksums, after_magic)
+
+    # check that the offset for the first block matches
+    if block_index[0] != first_block_offset:
+        msg = "Invalid block index contents for block 0, falling back to serial reading"
+        warnings.warn(msg, AsdfBlockIndexWarning)
+        fd.seek(starting_offset)
+        return _read_blocks_serially(fd, memmap, lazy_load, after_magic)
+
+    # skip magic for each block
+    return [ReadBlock(offset + magic_len, fd, memmap, lazy_load, validate_checksums) for offset in block_index]

--- a/asdf/_block/reader.py
+++ b/asdf/_block/reader.py
@@ -265,7 +265,7 @@ def read_blocks(
 
     # index says no blocks but we found block magic above, this so the index is wrong
     if not len(block_index):
-        msg = "Failed to read block index, falling back to serial reading"
+        msg = "Invalid block index contents, no offsets, falling back to serial reading"
         warnings.warn(msg, AsdfBlockIndexWarning)
         fd.seek(starting_offset)
         return _read_blocks_serially(fd, memmap, lazy_load, validate_checksums, after_magic)

--- a/asdf/_tests/_block/test_reader.py
+++ b/asdf/_tests/_block/test_reader.py
@@ -78,9 +78,7 @@ def test_read(tmp_path, lazy_load, memmap, with_index, validate_checksums, paddi
     ) as (fd, check):
         r = read_blocks(fd, memmap=memmap, lazy_load=lazy_load, validate_checksums=validate_checksums)
         if lazy_load and with_index and not streamed:
-            assert r[0].loaded
-            assert r[-1].loaded
-            for blk in r[1:-1]:
+            for blk in r:
                 assert not blk.loaded
                 # getting the header should load the block
                 blk.header
@@ -136,7 +134,7 @@ def test_read_post_padding_non_null_bytes():
             check(read_blocks(fd))
 
 
-@pytest.mark.parametrize("invalid_block_index", [0, 1, -1, "junk"])
+@pytest.mark.parametrize("invalid_block_index", [0, "junk"])
 def test_invalid_block_index(tmp_path, invalid_block_index):
     fn = tmp_path / "test.bin"
     with gen_blocks(fn=fn, with_index=True) as (fd, check):

--- a/asdf/_tests/_block/test_reader.py
+++ b/asdf/_tests/_block/test_reader.py
@@ -140,31 +140,25 @@ def test_invalid_block_index(invalid_type):
         # trash the block index
         offset = bio.find_block_index(fd)
         assert offset is not None
-        match invalid_type:
-            case "junk":
-                # trash the whole index
-                fd.seek(-4, 2)
-                fd.write(b"junk")
-            case "first":
-                # mess up the first entry of the index
-                block_index = bio.read_block_index(fd, offset)
-                block_index[0] += 4
-                fd.seek(offset)
-                bio.write_block_index(fd, block_index)
-            case "empty":
-                # write out an empty index
-                fd.seek(offset)
-                bio.write_block_index(fd, [])
+        if invalid_type == "junk":
+            # trash the whole index
+            fd.seek(-4, 2)
+            fd.write(b"junk")
+            ctx = pytest.warns(AsdfBlockIndexWarning, match="Failed to read block index")
+        elif invalid_type == "first":
+            # mess up the first entry of the index
+            block_index = bio.read_block_index(fd, offset)
+            block_index[0] += 4
+            fd.seek(offset)
+            bio.write_block_index(fd, block_index)
+            ctx = pytest.warns(AsdfBlockIndexWarning, match="Invalid block index contents")
+        else:  # "empty"
+            # write out an empty index
+            fd.seek(offset)
+            bio.write_block_index(fd, [])
+            ctx = pytest.warns(AsdfBlockIndexWarning, match="Invalid block index contents")
         fd.truncate()
         fd.seek(0)
-
-        # when the block index is read, only the first and last blocks
-        # are check, so any other invalid entry should result in failure
-        match invalid_type:
-            case "junk":
-                ctx = pytest.warns(AsdfBlockIndexWarning, match="Failed to read block index")
-            case "first" | "empty":
-                ctx = pytest.warns(AsdfBlockIndexWarning, match="Invalid block index contents")
         with ctx:
             check(read_blocks(fd, lazy_load=True))
 

--- a/asdf/_tests/_block/test_reader.py
+++ b/asdf/_tests/_block/test_reader.py
@@ -134,36 +134,39 @@ def test_read_post_padding_non_null_bytes():
             check(read_blocks(fd))
 
 
-@pytest.mark.parametrize("invalid_block_index", [0, "junk"])
-def test_invalid_block_index(tmp_path, invalid_block_index):
-    fn = tmp_path / "test.bin"
-    with gen_blocks(fn=fn, with_index=True) as (fd, check):
+@pytest.mark.parametrize("invalid_type", ["junk", "first", "empty"])
+def test_invalid_block_index(invalid_type):
+    with gen_blocks(with_index=True) as (fd, check):
         # trash the block index
         offset = bio.find_block_index(fd)
         assert offset is not None
-        if invalid_block_index == "junk":
-            # trash the whole index
-            fd.seek(-4, 2)
-            fd.write(b"junk")
-        else:  # mess up one entry of the index
-            block_index = bio.read_block_index(fd, offset)
-            block_index[invalid_block_index] += 4
-            fd.seek(offset)
-            bio.write_block_index(fd, block_index)
+        match invalid_type:
+            case "junk":
+                # trash the whole index
+                fd.seek(-4, 2)
+                fd.write(b"junk")
+            case "first":
+                # mess up the first entry of the index
+                block_index = bio.read_block_index(fd, offset)
+                block_index[0] += 4
+                fd.seek(offset)
+                bio.write_block_index(fd, block_index)
+            case "empty":
+                # write out an empty index
+                fd.seek(offset)
+                bio.write_block_index(fd, [])
+        fd.truncate()
         fd.seek(0)
 
         # when the block index is read, only the first and last blocks
         # are check, so any other invalid entry should result in failure
-        if invalid_block_index in (0, -1):
-            with pytest.warns(AsdfBlockIndexWarning, match="Invalid block index contents"):
-                check(read_blocks(fd, lazy_load=True))
-        elif invalid_block_index == "junk":
-            # read_blocks should fall back to reading serially
-            with pytest.warns(AsdfBlockIndexWarning, match="Failed to read block index"):
-                check(read_blocks(fd, lazy_load=True))
-        else:
-            with pytest.raises(ValueError, match=r"Header size.*"):
-                check(read_blocks(fd, lazy_load=True))
+        match invalid_type:
+            case "junk":
+                ctx = pytest.warns(AsdfBlockIndexWarning, match="Failed to read block index")
+            case "first" | "empty":
+                ctx = pytest.warns(AsdfBlockIndexWarning, match="Invalid block index contents")
+        with ctx:
+            check(read_blocks(fd, lazy_load=True))
 
 
 def test_invalid_block_in_index_with_valid_magic(tmp_path):

--- a/asdf/_tests/tags/core/tests/test_ndarray.py
+++ b/asdf/_tests/tags/core/tests/test_ndarray.py
@@ -212,7 +212,7 @@ def test_dont_load_data():
         repr(ff.tree)
 
         for block in ff._blocks.blocks:
-            assert callable(block._data)
+            assert not block.loaded
 
 
 def test_table_inline():

--- a/asdf/_tests/test_api.py
+++ b/asdf/_tests/test_api.py
@@ -503,7 +503,7 @@ def test_array_access_after_file_close(tmp_path):
     # the file has been closed:
     with asdf.open(path) as af:
         tree = af.tree
-    with pytest.raises(OSError, match=r"ASDF file has already been closed. Can not get the data."):
+    with pytest.raises(OSError, match=r"Attempt to load block from closed file"):
         tree["data"][0]
 
     # With memory mapping disabled and copying arrays enabled,

--- a/asdf/_tests/test_array_blocks.py
+++ b/asdf/_tests/test_array_blocks.py
@@ -601,15 +601,13 @@ def test_block_index():
     buff.seek(0)
     with asdf.open(buff) as ff2:
         assert len(ff2._blocks.blocks) == 100
-        assert ff2._blocks.blocks[0].loaded
-        for i in range(2, 99):
+        for i in range(100):
             assert not ff2._blocks.blocks[i].loaded
-        assert ff2._blocks.blocks[99].loaded
 
         # Force the loading of one array
         ff2.tree["arrays"][50] * 2
 
-        for i in range(2, 99):
+        for i in range(100):
             if i == 50:
                 assert ff2._blocks.blocks[i].loaded
             else:
@@ -646,7 +644,6 @@ def test_large_block_index():
 
     buff.seek(0)
     with asdf.open(buff) as ff2:
-        assert ff2._blocks.blocks[0].loaded
         assert len(ff2._blocks.blocks) == narrays
 
 
@@ -711,38 +708,7 @@ def test_short_file_find_block_index():
             assert ff._blocks.blocks[1].loaded
 
 
-def test_invalid_block_index_values():
-    # This adds a value in the block index that points to something
-    # past the end of the file.  In that case, we should just reject
-    # the index altogether.
-
-    buff = generic_io.get_file(io.BytesIO(), mode="w")
-
-    arrays = []
-    for i in range(10):
-        arrays.append(np.ones((8, 8)) * i)
-
-    tree = {"arrays": arrays}
-
-    ff = asdf.AsdfFile(tree)
-    ff.write_to(buff, include_block_index=True)
-    buff.seek(0)
-    offset = bio.find_block_index(buff)
-    assert offset is not None, "Failed to find block index"
-    buff.seek(offset)
-    block_index = bio.read_block_index(buff)
-    block_index.append(123456789)
-    buff.seek(offset)
-    bio.write_block_index(buff, block_index)
-
-    buff.seek(0)
-    with pytest.warns(AsdfBlockIndexWarning, match="Invalid block index contents"):
-        with asdf.open(buff) as ff:
-            assert len(ff._blocks.blocks) == 10
-            assert ff._blocks.blocks[1].loaded
-
-
-@pytest.mark.parametrize("block_index_index", [0, -1])
+@pytest.mark.parametrize("block_index_index", [0])
 def test_invalid_block_index_offset(block_index_index):
     """
     This adds a value in the block index that points to something
@@ -996,6 +962,7 @@ def test_open_memmap_from_closed_file(tmp_path):
     with pytest.raises(OSError, match=msg):
         view[:]
 
+    msg = r"Attempt to load block from closed file"
     with pytest.raises(OSError, match=msg):
         base2[:]
 

--- a/changes/2056.feature.rst
+++ b/changes/2056.feature.rst
@@ -1,0 +1,1 @@
+Change block index parsing to only check the first block header. This improves IO performance (especially for remote files) by removing several file seeks and reads.


### PR DESCRIPTION
Prior to this PR the first and last blocks were loaded.

Now, prior to the index finding the start of the first block is found
The first blocks typically starts immediately after the tree.
This is nice because the code just finished reading the tree meaning
checking for the first block should usually only take reading 4 bytes
to read the block magic. The exception is when the tree is padded.
Here the entire padding needs to be read.

Now that the code knows where the first block starts, it uses
that offset to check the block index (if one is found). If the
first index doesn't match, the code falls back to reading serially.
If it matches, the code uses the block index.

This access pattern should be more efficient (and a better match
to cloud access) where the old code did something like the following.

=== old routine ===

Assume we have a file with:
[ ---- tree --- _padding_ blk0 blk1 ... blkN index ]

For old and new reading starts with the tree
             fp index
                |
[ ---- tree --- ********************************** ]

For old next the index was found which required a seek to the end
then reading backwards to find the index
                |----------------------- seek --->|
[ ---- tree --- **************************** index ]

then a seek to the start to read the first block (after padding)
                          |<-seek-----------------|
[ ---- tree --- _padding_ blk0 ************* index ]

then a seek to the last block and read it
                              ---seek->|
[ ---- tree --- _padding_ blk0 ******** blkN index ]

=== new routine ===

For the new routine the process is simplier and starts the same with
reading the tree:
             fp index
                |
[ ---- tree --- ********************************** ]

Then the first block is found (just the magic)
                          |
[ ---- tree --- _padding_ ************************ ]

Then the file is searched for a block index (and read):
                          |-------------- seek --->|
[ ---- tree --- _padding_ *******************index ]

and that's it.

One possible (and very unlikey) downside is if a file somehow has
- a valid block index
- a valid first block offset
- an invalid last block offset

we would not catch the error (but we would before). It seems impossible
to generate such a file without manually modifying block headers. If
that's happening there is no reason non first/last blocks might also
be incorrect so the old routine was also not absolute.

## Tasks

- [ ] [run `prek` on your machine](https://prek.j178.dev/quickstart/)
- [ ] run `pytest` on your machine
- [ ] Does this PR add new features and / or change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
    - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
    - [ ] update relevant docstrings and / or `docs/` page
    - [ ] for any new features, add unit tests

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: bug fix
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
