### PR TITLE
Only treat ancestor references as recursive in info() (fixes #1891)

### DIFF
--- a/asdf/_node_info.py
+++ b/asdf/_node_info.py
@@ -350,19 +350,25 @@ class NodeSchemaInfo:
         """
         extension_manager = extension_manager or _get_extension_manager()
 
-        current_nodes = [(None, root_identifier, root_node)]
-        seen = set()
+        # Each queued node carries the set of ``id()``s of its ancestors (the
+        # nodes along the path from the root to it). A node is a recursive
+        # reference only when it appears within its own ancestry, i.e. a real
+        # cycle. Tracking this per-branch (rather than tree-wide) means that an
+        # object simply shared between sibling branches -- for example the empty
+        # tuple ``()`` assigned to two keys -- is no longer misreported as
+        # recursive (see GH #1891).
+        current_nodes = [(None, root_identifier, root_node, frozenset())]
         root_info = None
         current_depth = 0
         while True:
             next_nodes = []
 
-            for parent, identifier, node in current_nodes:
+            for parent, identifier, node, ancestors in current_nodes:
                 # node is the item in the tree
                 # We might sometimes not want to use that node directly
                 # but instead using a different node for traversal.
                 t_node, traversable, _ = _make_traversable(node, extension_manager)
-                if (is_container(node) or traversable) and id(node) in seen:
+                if (is_container(node) or traversable) and id(node) in ancestors:
                     info = NodeSchemaInfo(
                         key,
                         parent,
@@ -394,10 +400,11 @@ class NodeSchemaInfo:
                         # track that this node is a child of the parent
                         parent.children.append(info)
 
-                    # Track which nodes have been seen to avoid an infinite
-                    # loop and to find recursive references
-                    # This is tree wide but should be per-branch.
-                    seen.add(id(node))
+                    # The ancestry passed to this node's children includes this
+                    # node, so that a child which refers back to one of its own
+                    # ancestors (a genuine cycle) is detected as recursive while
+                    # the traversal still terminates.
+                    child_ancestors = ancestors | {id(node)}
 
                     # if the node has __asdf_traverse__ and a _tag attribute
                     # that is a valid tag, load it's schema
@@ -414,7 +421,7 @@ class NodeSchemaInfo:
 
                     # add children to queue
                     for child_identifier, child_node in get_children(t_node):
-                        next_nodes.append((info, child_identifier, child_node))
+                        next_nodes.append((info, child_identifier, child_node, child_ancestors))
 
             if len(next_nodes) == 0:
                 break

--- a/asdf/_tests/test_info.py
+++ b/asdf/_tests/test_info.py
@@ -832,6 +832,36 @@ def test_info_no_infinite_loop(capsys):
     assert "recursive" in captured.out
 
 
+def test_info_shared_object_not_recursive(capsys):
+    """
+    An object shared between sibling branches (here the empty tuple ``()``
+    assigned to two keys) is not a recursive reference and must not be
+    reported as one. Regression test for GH #1891.
+    """
+    af = asdf.AsdfFile()
+    af["l"] = af["l2"] = ()
+    af.info()
+    captured = capsys.readouterr()
+    assert "recursive reference" not in captured.out
+
+
+def test_info_shared_subtree_shown_fully(capsys):
+    """
+    A non-recursive subtree referenced from two places should be displayed in
+    full at each location rather than the second occurrence being collapsed to
+    a (recursive reference). Regression test for GH #1891.
+    """
+    af = asdf.AsdfFile()
+    shared = {"value": 42}
+    af["a"] = shared
+    af["b"] = shared
+    af.info()
+    captured = capsys.readouterr()
+    assert "recursive reference" not in captured.out
+    # The shared mapping's contents appear under both "a" and "b".
+    assert captured.out.count("value (int): 42") == 2
+
+
 def _get_block_output(capsys, af, *args, **kwargs) -> str:
     """Passes provided arguments to both `asdf.info` and `AsdfFile.info` and verifies the outputs match.
 

--- a/changes/2058.bugfix.rst
+++ b/changes/2058.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed ``AsdfFile.info`` reporting an object shared between sibling
+branches (for example the same tuple assigned to two keys) as a
+``(recursive reference)`` when there is no cycle.


### PR DESCRIPTION
Fixes #1891.

## Problem

`info()` reports a node as a `(recursive reference)` whenever the same object has been seen anywhere earlier in the tree, not only when it is part of an actual cycle. An object shared between sibling branches is therefore mislabelled:

```python
>>> import asdf
>>> af = asdf.AsdfFile()
>>> af["l"] = af["l2"] = ()
>>> af.info()
root (AsdfObject)
├─l (tuple): ()
└─l2 (tuple): () (recursive reference)
```

There is no recursion here — `l` and `l2` simply refer to the same (empty-tuple) object.

## Cause

`NodeSchemaInfo.from_root_node` walks the tree breadth-first and records every visited node in a single tree-wide `seen` set, flagging any repeat as recursive. The existing code even noted this:

```python
# This is tree wide but should be per-branch.
seen.add(id(node))
```

## Fix

Each queued node now carries the set of `id()`s of its ancestors (the nodes on the path from the root to it). A node is flagged as recursive only when its own `id` appears in that ancestor set — i.e. a genuine cycle. Genuine self-references are still detected and the traversal still terminates (a recursive node is not descended into); acyclic shared subtrees are now displayed in full at each location.

## Tests

Added `test_info_shared_object_not_recursive` (the `()` case from the issue) and `test_info_shared_subtree_shown_fully` (a shared non-empty mapping shown in full under both keys). Both fail on `main` and pass with this change. The existing `test_recursive_info_object_support` and `test_info_no_infinite_loop` (true-cycle / infinite-loop guards) still pass.