### PR TITLE
Add deprecation warning for reading non-seekable files

### DIFF
--- a/asdf/_asdf.py
+++ b/asdf/_asdf.py
@@ -11,6 +11,7 @@ import weakref
 from typing import TYPE_CHECKING, overload
 
 from packaging.version import Version
+from typing_extensions import Reader, Writer, deprecated
 
 from . import _compression as mcompression
 from . import _display as display
@@ -46,6 +47,7 @@ if TYPE_CHECKING:
         FileMode,
         FilterFn,
         NDArray,
+        PathLike,
         TreeKey,
     )
 
@@ -959,6 +961,32 @@ class AsdfFile:
             if fd.can_memmap():
                 fd.close_memmap()
 
+    @overload
+    def write_to(
+        self,
+        fd: PathLike | io.IOBase | GenericFile,
+        all_array_storage: ArrayStorage | NotSet = ...,
+        all_array_compression: Compression | NotSet = ...,
+        compression_kwargs: dict[str, Any] | NotSet = ...,
+        pad_blocks: bool | float = ...,
+        include_block_index: bool = ...,
+        version: str | None = ...,
+        write_checksums: bool = ...,
+    ) -> None: ...
+    @overload
+    @deprecated("Duck-typed file objects are deprecated. Use an instance of IOBase instead.")
+    def write_to(
+        self,
+        fd: Reader | Writer,
+        all_array_storage: ArrayStorage | NotSet = ...,
+        all_array_compression: Compression | NotSet = ...,
+        compression_kwargs: dict[str, Any] | NotSet = ...,
+        pad_blocks: bool | float = ...,
+        include_block_index: bool = ...,
+        version: str | None = ...,
+        write_checksums: bool = ...,
+    ) -> None: ...
+
     def write_to(
         self,
         fd: FileLike,
@@ -1333,6 +1361,41 @@ class AsdfFile:
     # a context when one isn't explicitly passed in.
     def _create_serialization_context(self, operation=_serialization_context.BlockAccess.NONE):
         return _serialization_context.create(self, operation)
+
+
+@overload
+def open_asdf(
+    fd: PathLike | io.IOBase | GenericFile,
+    uri: str | None = ...,
+    mode: FileMode | None = ...,
+    validate_checksums: bool = ...,
+    extensions: ExtensionLike | Sequence[ExtensionLike] | None = ...,
+    ignore_unrecognized_tag: bool = ...,
+    _force_raw_types: bool = ...,
+    memmap: bool = ...,
+    lazy_tree: bool | NotSet = ...,
+    lazy_load: bool = ...,
+    custom_schema: str | None = ...,
+    strict_extension_check: bool = ...,
+    ignore_missing_extensions: bool = ...,
+) -> AsdfFile: ...
+@overload
+@deprecated("Duck-typed file objects are deprecated. Use an instance of IOBase instead.")
+def open_asdf(
+    fd: Reader | Writer,
+    uri: str | None = ...,
+    mode: FileMode | None = ...,
+    validate_checksums: bool = ...,
+    extensions: ExtensionLike | Sequence[ExtensionLike] | None = ...,
+    ignore_unrecognized_tag: bool = ...,
+    _force_raw_types: bool = ...,
+    memmap: bool = ...,
+    lazy_tree: bool | NotSet = ...,
+    lazy_load: bool = ...,
+    custom_schema: str | None = ...,
+    strict_extension_check: bool = ...,
+    ignore_missing_extensions: bool = ...,
+) -> AsdfFile: ...
 
 
 def open_asdf(

--- a/asdf/_tests/_regtests/test_1542.py
+++ b/asdf/_tests/_regtests/test_1542.py
@@ -17,7 +17,7 @@ def test_failure_to_write_blocks_to_non_seekable_file():
     https://github.com/asdf-format/asdf/issues/1542
     """
     r, w = os.pipe()
-    with os.fdopen(r, "rb") as rf:
+    with os.fdopen(r, "rb") as rf, pytest.deprecated_call():
         with os.fdopen(w, "wb") as wf:
             arrs = [np.zeros(1, dtype="uint8") + i for i in range(10)]
             af = asdf.AsdfFile({"arrs": arrs})

--- a/asdf/_tests/test_api.py
+++ b/asdf/_tests/test_api.py
@@ -102,8 +102,9 @@ def test_open_stream(tmp_path):
         def read(self, size=-1):
             return self._fd.read(size)
 
-    with file_path.open("rb") as fd, asdf.open(StreamWrapper(fd)) as af:
-        assert af["foo"] == "bar"
+    with pytest.deprecated_call():
+        with file_path.open("rb") as fd, asdf.open(StreamWrapper(fd)) as af:
+            assert af["foo"] == "bar"
 
 
 def test_atomic_write(tmp_path, small_tree):

--- a/asdf/_tests/test_asdf.py
+++ b/asdf/_tests/test_asdf.py
@@ -178,7 +178,7 @@ def test_open_asdf_extensions(tmp_path):
     msg = r"[The extensions parameter must be an extension.*, Extension must implement the Extension interface]"
     for arg in (object(), [object()]):
         # Intentionally incorrect extension type
-        # pyrefly: ignore[bad-argument-type]
+        # pyrefly: ignore[no-matching-overload]
         with pytest.raises(TypeError, match=msg), open_asdf(path, extensions=arg) as af:
             pass
 

--- a/asdf/_tests/test_compression.py
+++ b/asdf/_tests/test_compression.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytest
 
 import asdf
-from asdf import _compression, config_context, generic_io
+from asdf import _compression, config_context
 from asdf._tests import _helpers as helpers
 from asdf.extension import Compressor, Extension
 
@@ -67,10 +67,10 @@ def _roundtrip(
     buff = io.BytesIO()
 
     ff = asdf.AsdfFile(tree)
-    ff.write_to(generic_io.OutputStream(buff), **write_options)
+    ff.write_to(buff, **write_options)
 
     buff.seek(0)
-    with asdf.open(generic_io.InputStream(buff), **read_options) as ff:
+    with asdf.open(buff, **read_options) as ff:
         helpers.assert_tree_match(tree, ff.tree)
 
     return tmpfile

--- a/asdf/_tests/test_generic_io.py
+++ b/asdf/_tests/test_generic_io.py
@@ -44,7 +44,8 @@ def test_mode_fail(tmp_path):
     path = os.path.join(str(tmp_path), "test.asdf")
 
     with pytest.raises(ValueError, match=r"mode must be 'r', 'w' or 'rw'"):
-        generic_io.get_file(path, mode="r+")  # pyrefly: ignore[bad-argument-type]
+        # pyrefly: ignore[no-matching-overload]
+        generic_io.get_file(path, mode="r+")
 
 
 @pytest.mark.parametrize("mode", ["r", "w", "rw"])
@@ -245,7 +246,8 @@ def test_urlopen(tree, httpserver):
         return generic_io.get_file(open(path, "wb"), mode="w")
 
     def get_read_fd():
-        return generic_io.get_file(urllib_request.urlopen(httpserver.url + "test.asdf"))
+        with pytest.deprecated_call():
+            return generic_io.get_file(urllib_request.urlopen(httpserver.url + "test.asdf"))
 
     with _roundtrip(tree, get_write_fd, get_read_fd) as ff:
         assert len(ff._blocks.blocks) == 2
@@ -374,7 +376,7 @@ def test_open_stdout():
 def test_invalid_obj(tmp_path):
     with pytest.raises(ValueError, match=r"Can't handle .* as a file for mode 'r'"):
         # Intentionally incorrect file type
-        # pyrefly: ignore[bad-argument-type]
+        # pyrefly: ignore[no-matching-overload]
         generic_io.get_file(42)
 
     path = os.path.join(str(tmp_path), "test.asdf")
@@ -416,12 +418,14 @@ def test_nonseekable_file(tmp_path):
             return True
 
     with FileWrapper(os.path.join(str(tmp_path), "test.asdf"), "wb") as fd:
-        assert isinstance(generic_io.get_file(fd, "w"), generic_io.OutputStream)
-        with pytest.raises(ValueError, match=r"File .* could not be opened in 'rw' mode"):
-            generic_io.get_file(fd, "rw")
+        with pytest.deprecated_call():
+            assert isinstance(generic_io.get_file(fd, "w"), generic_io.OutputStream)
+            with pytest.raises(ValueError, match=r"File .* could not be opened in 'rw' mode"):
+                generic_io.get_file(fd, "rw")
 
     with FileWrapper(os.path.join(str(tmp_path), "test.asdf"), "rb") as fd:
-        assert isinstance(generic_io.get_file(fd, "r"), generic_io.InputStream)
+        with pytest.deprecated_call():
+            assert isinstance(generic_io.get_file(fd, "r"), generic_io.InputStream)
 
 
 def test_relative_uri():
@@ -478,19 +482,22 @@ def test_arbitrary_file_object():
         pass
 
     buff = io.BytesIO()
-    assert isinstance(generic_io.get_file(Reader(buff), "r"), generic_io.InputStream)
-    assert isinstance(generic_io.get_file(Writer(buff), "w"), generic_io.OutputStream)
-    assert isinstance(generic_io.get_file(RandomReader(buff), "r"), generic_io.MemoryIO)
-    assert isinstance(generic_io.get_file(RandomWriter(buff), "w"), generic_io.MemoryIO)
-    assert isinstance(generic_io.get_file(All(buff), "rw"), generic_io.MemoryIO)
-    assert isinstance(generic_io.get_file(All(buff), "r"), generic_io.MemoryIO)
-    assert isinstance(generic_io.get_file(All(buff), "w"), generic_io.MemoryIO)
+    with pytest.deprecated_call():
+        assert isinstance(generic_io.get_file(Reader(buff), "r"), generic_io.InputStream)
+        assert isinstance(generic_io.get_file(Writer(buff), "w"), generic_io.OutputStream)
+        assert isinstance(generic_io.get_file(RandomReader(buff), "r"), generic_io.MemoryIO)
+        assert isinstance(generic_io.get_file(RandomWriter(buff), "w"), generic_io.MemoryIO)
+        assert isinstance(generic_io.get_file(All(buff), "rw"), generic_io.MemoryIO)
+        assert isinstance(generic_io.get_file(All(buff), "r"), generic_io.MemoryIO)
+        assert isinstance(generic_io.get_file(All(buff), "w"), generic_io.MemoryIO)
 
     with pytest.raises(ValueError, match=r"Can't handle .* as a file for mode 'w'"):
-        generic_io.get_file(Reader(buff), "w")
+        with pytest.deprecated_call():
+            generic_io.get_file(Reader(buff), "w")
 
     with pytest.raises(ValueError, match=r"Can't handle .* as a file for mode 'r'"):
-        generic_io.get_file(Writer(buff), "r")
+        with pytest.deprecated_call():
+            generic_io.get_file(Writer(buff), "r")
 
 
 def test_check_bytes(tmp_path):

--- a/asdf/_tests/test_util.py
+++ b/asdf/_tests/test_util.py
@@ -87,7 +87,8 @@ def test_get_file_type(content, expected_type):
         def read(self, size=-1):
             return self._fd.read(size)
 
-    fd = generic_io.get_file(OnlyHasAReadMethod(content))
+    with pytest.deprecated_call():
+        fd = generic_io.get_file(OnlyHasAReadMethod(content))
     assert util.get_file_type(fd) == expected_type
     assert fd.read() == content
 

--- a/asdf/generic_io.py
+++ b/asdf/generic_io.py
@@ -16,11 +16,13 @@ import pathlib
 import re
 import sys
 import typing
+import warnings
 from os import SEEK_CUR, SEEK_END, SEEK_SET
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, overload
 from urllib.request import url2pathname
 
 import numpy as np
+from typing_extensions import Reader, Writer, deprecated
 
 from ._extern import atomicfile
 from .exceptions import DelimiterNotFoundError
@@ -31,7 +33,7 @@ if TYPE_CHECKING:
 
     from fsspec.core import OpenFile
 
-    from asdf.typing import ByteArray1D, FileLike, FileMode, Reader
+    from asdf.typing import ByteArray1D, FileLike, FileMode, PathLike, Reader
 
 __all__ = ["GenericFile", "get_file", "get_uri", "relative_uri", "resolve_uri"]
 
@@ -1000,6 +1002,23 @@ def get_uri(file_obj):
     return getattr(file_obj, "name", "")
 
 
+@overload
+def get_file(
+    init: PathLike | io.IOBase | GenericFile,
+    mode: FileMode = ...,
+    uri: str | None = ...,
+    close: bool = ...,
+) -> GenericFile: ...
+@overload
+@deprecated("Duck-typed file objects are deprecated. Use an instance of IOBase instead.")
+def get_file(
+    init: Reader | Writer,
+    mode: FileMode = ...,
+    uri: str | None = ...,
+    close: bool = ...,
+) -> GenericFile: ...
+
+
 def get_file(
     init: FileLike,
     mode: FileMode = "r",
@@ -1133,6 +1152,23 @@ def get_file(
     if isinstance(init, io.StringIO):
         msg = "io.StringIO objects are not supported.  Use io.BytesIO instead."
         raise TypeError(msg)
+
+    if not isinstance(init, io.IOBase):
+        # Only generate a warning if its an actual duck-typed file.
+        # If its just a random object it will raise a ValueError below anyway.
+        if hasattr(init, "read") or hasattr(init, "write"):
+            warnings.warn(
+                "Duck-typed file objects are deprecated. Use an instance of IOBase instead.",
+                DeprecationWarning,
+            )
+    elif not init.seekable() and mode != "w":
+        warnings.warn(
+            (
+                "Reading from non-seekable files is deprecated. "
+                "Consider implementing seek() or reading the file into a BytesIO instance."
+            ),
+            DeprecationWarning,
+        )
 
     if isinstance(init, io.IOBase):
         if ("r" in mode and not init.readable()) or ("w" in mode and not init.writable()):

--- a/changes/2059.removal.rst
+++ b/changes/2059.removal.rst
@@ -1,0 +1,2 @@
+Deprecated support for duck-typed files that aren't instances of ``IOBase``.
+Deprecated reading from non-seekable files.


### PR DESCRIPTION
## Description
* This PR deprecates reading from non-seekable files. 
  * By extension this requires deprecating support for duck-typed files (e.g. objects with just a `read` or `write` method)
  * The only non-deprecated file objects supported moving forward are ones that subclass `IOBase`.
  * We could potentially continue to support duck-typed files by checking if they have a `seekable` attribute, but requiring `IOBase` provides better future opportunities for simplifying/removing `generic_io` since we can assume the availability of significantly more file methods.
* Added overloads for `AsdfFile.write_to`, `open_asdf`, and `generic_io.get_file`:
  * First overload matches the supported file argument types (`Path | str | IOBase | GenericFile`)
  * Second overload matches duck-typed files (`Reader | Writer`) and has a `@deprecated` decorator
* Added runtime deprecation warnings to `generic_io.get_file` if file is duck-typed or if `mode != "w"` and file is not seekable.
* Updated relevant tests to add a `with pytest.deprecated_call():` block around tests that use non-seekable or duck-typed files.

Closes #2050