### PR TITLE
Removed `pytest-run-parallel` package in sunpy tox config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -302,6 +302,10 @@ commands_pre =
     git clone https://github.com/sunpy/sunpy.git
     pip install -e sunpy[tests,all]
     pip install -r {env_tmp_dir}/requirements.txt
+    # Removing to work around incompatibility with pytest-asdf-plugin
+    # This line can be removed once a new plugin version is released
+    # https://github.com/asdf-format/pytest-asdf-plugin/pull/15
+    pip uninstall -y pytest-run-parallel
     pip freeze
 commands =
     pytest sunpy/sunpy/io


### PR DESCRIPTION
## Description
* Updated sunpy environment in tox.ini to remove `pytest-run-parallel` plugin

This change allows the sunpy downstream CI job to pass by working around an incompatibility between `pytest-run-parallel` and `pytest-asdf-plugin`.

There is an active PR for `pytest-asdf-plugin` to resolve the incompatibility (https://github.com/asdf-format/pytest-asdf-plugin/pull/15), but that PR is itself blocked waiting for a fix in `pytest-run-parallel` (https://github.com/Quansight-Labs/pytest-run-parallel/issues/180).

Since it might take a bit for both plugins to merge the changes and generate new releases, this PR provides a temporary workaround so our downstream CI stops failing.