### PR TITLE
5p3p1 release

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -73,4 +73,5 @@ jobs:
         - linux: weldx
         - linux: sunpy
         - linux: dkist
+        - linux: dkist-inventory
         - linux: abacusutils

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,20 +43,11 @@ repos:
       exclude: "asdf/(extern||_jsonschema)/.*"
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: 'v0.13.0'
+  rev: 'v0.15.12'
   hooks:
-    - id: ruff
+    - id: ruff-check
       args: ["--fix"]
-
-- repo: https://github.com/psf/black
-  rev: 25.1.0
-  hooks:
-    - id: black
-
-- repo: https://github.com/asottile/blacken-docs
-  rev: '1.20.0'
-  hooks:
-    - id: blacken-docs
+    - id: ruff-format
 
 - repo: https://github.com/tombi-toml/tombi-pre-commit
   rev: v0.9.25

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,7 +59,9 @@ repos:
     - id: blacken-docs
 
 - repo: https://github.com/tombi-toml/tombi-pre-commit
-  rev: v0.9.17
+  rev: v0.9.25
   hooks:
     - id: tombi-format
+      args: ["--offline"]
     - id: tombi-lint
+      args: ["--offline"]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,13 @@
+5.3.1 (2026-06-08)
+==================
+
+Bugfix
+------
+
+- Fix bug where ``add_history_entry`` incorrectly used a custom schema if
+  available. (`#2044 <https://github.com/asdf-format/asdf/pull/2044>`_)
+
+
 5.3.0 (2026-04-23)
 ==================
 

--- a/asdf/_asdf.py
+++ b/asdf/_asdf.py
@@ -1099,6 +1099,7 @@ class AsdfFile:
         schema.validate(
             yamlutil.custom_tree_to_tagged_tree({"entry": entry}, self),
             ctx=self,
+            schema={},
         )
 
         if self.version >= versioning.NEW_HISTORY_FORMAT_MIN_VERSION:

--- a/asdf/_display.py
+++ b/asdf/_display.py
@@ -40,7 +40,7 @@ def render_table(
     inner_width = key_width + val_width + 1
 
     # Format each row with key left-aligned and value centered
-    content = [f"┃ {key:<{key_width-2}} │ {value:^{val_width-2}} ┃" for key, value in rows]
+    content = [f"┃ {key:<{key_width - 2}} │ {value:^{val_width - 2}} ┃" for key, value in rows]
     return [
         "┏" + "━" * inner_width + "┓",
         f"┃{title:^{inner_width}s}┃",  # Centered table title

--- a/asdf/_tests/test_history.py
+++ b/asdf/_tests/test_history.py
@@ -293,3 +293,18 @@ def test_history_validate():
     with pytest.raises(ValidationError):
         af.add_history_entry(1)
     assert len(af.get_history_entries()) == 1
+
+
+def test_history_ignores_custom_schema(tmp_path):
+    """
+    Test that add_history_entry doesn't use any provided custom schema.
+    """
+    fn = tmp_path / "custom.yaml"
+    with open(fn, "w") as f:
+        f.write("required: ['foo']")
+    af = asdf.AsdfFile(version="1.6.0", custom_schema=fn)
+    with pytest.raises(ValidationError):
+        af.validate()
+
+    af.add_history_entry("test")
+    assert af.get_history_entries()[0]["description"] == "test"

--- a/asdf/_tests/test_info.py
+++ b/asdf/_tests/test_info.py
@@ -786,9 +786,7 @@ properties:
         properties:
             bar:
                 title: bar_title
-""".encode(
-        "ascii"
-    )
+""".encode("ascii")
 
     class MyExtension:
         extension_uri = "asdf://somewhere.org/extensions/foo-1.0.0"

--- a/asdf/_tests/test_reference.py
+++ b/asdf/_tests/test_reference.py
@@ -174,7 +174,9 @@ def test_make_reference(tmp_path):
 
         ff.write_to(os.path.join(str(tmp_path), "source.asdf"))
 
-    with (asdf.open(os.path.join(str(tmp_path), "source.asdf")) as ff,):
+    with (
+        asdf.open(os.path.join(str(tmp_path), "source.asdf")) as ff,
+    ):
         ff.find_references()
         assert ff.tree["ref"]._uri == "external.asdf#f~0o~0o~1/a"
 

--- a/asdf/tags/core/external_reference.py
+++ b/asdf/tags/core/external_reference.py
@@ -30,7 +30,7 @@ class ExternalArrayReference:
 
     >>> import asdf
     >>> ref = asdf.ExternalArrayReference("myfitsfile.fits", 1, "float64", (100, 100))
-    >>> tree = {'reference': ref}
+    >>> tree = {"reference": ref}
     >>> with asdf.AsdfFile(tree) as ff:
     ...     ff.write_to("test.asdf")
 

--- a/asdf/tags/core/integer.py
+++ b/asdf/tags/core/integer.py
@@ -33,9 +33,9 @@ class IntegerType:
     >>> # Store the large integer value to the tree using asdf.IntegerType
     >>> tree = dict(largeval=asdf.IntegerType(largeval))
     >>> with asdf.AsdfFile(tree) as af:
-    ...     af.write_to('largeval.asdf')
-    >>> with asdf.open('largeval.asdf') as aa:
-    ...     assert aa['largeval'] == largeval
+    ...     af.write_to("largeval.asdf")
+    >>> with asdf.open("largeval.asdf") as aa:
+    ...     assert aa["largeval"] == largeval
     """
 
     def __init__(self, value, storage_type="internal"):

--- a/changes/2044.bugfix.rst
+++ b/changes/2044.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug where ``add_history_entry`` incorrectly used a custom schema if available.

--- a/changes/2044.bugfix.rst
+++ b/changes/2044.bugfix.rst
@@ -1,1 +1,0 @@
-Fix bug where ``add_history_entry`` incorrectly used a custom schema if available.

--- a/changes/2057.doc.rst
+++ b/changes/2057.doc.rst
@@ -1,0 +1,1 @@
+Remove some use of sphinx-asdf in docs.

--- a/docs/asdf/arrays.rst
+++ b/docs/asdf/arrays.rst
@@ -15,24 +15,43 @@ floating-point numbers (using `numpy.random.rand`).  Note that the resulting
 YAML output contains information about the structure (size and data type) of
 the array, but the actual array content is in a binary block.
 
-.. runcode::
+.. code:: python
 
-   from asdf import AsdfFile
-   import numpy as np
+   >>> from asdf import AsdfFile
+   >>> import numpy as np
 
-   tree = {'my_array': np.random.rand(8, 8)}
-   ff = AsdfFile(tree)
-   ff.write_to("array.asdf")
+   >>> tree = {'my_array': np.random.rand(8, 8)}
+   >>> ff = AsdfFile(tree)
+   >>> ff.write_to("array.asdf")
 
 .. note::
 
    In the file examples below, the first YAML part appears as it
-   appears in the file.  The ``BLOCK`` sections are stored as binary
-   data in the file, but are presented in human-readable form on this
-   page.
+   appears in the file.  Binary blocks are not shown as they are not
+   human-readable.
 
+.. code:: yaml
 
-.. asdf:: array.asdf
+   #ASDF 1.0.0
+   #ASDF_STANDARD 1.6.0
+   %YAML 1.1
+   %TAG ! tag:stsci.edu:asdf/
+   --- !core/asdf-1.1.0
+   asdf_library: !core/software-1.0.0 {author: The ASDF Developers, homepage: 'http://github.com/asdf-format/asdf',
+     name: asdf, version: 5.3.0}
+   history:
+     extensions:
+     - !core/extension_metadata-1.0.0
+       extension_class: asdf.extension._manifest.ManifestExtension
+       extension_uri: asdf://asdf-format.org/core/extensions/core-1.6.0
+       manifest_software: !core/software-1.0.0 {name: asdf_standard, version: 1.5.0}
+       software: !core/software-1.0.0 {name: asdf, version: 5.3.0}
+   my_array: !core/ndarray-1.1.0
+     source: 0
+     datatype: float64
+     byteorder: little
+     shape: [8, 8]
+   ...
 
 See :ref:`overview_reading` for a description of how to open this file.
 
@@ -45,19 +64,19 @@ data in the file.  In this example an array and a subview on that same
 array are saved to the same file, resulting in only a single block of
 data being saved.
 
-.. runcode::
+.. code:: python
 
-   from asdf import AsdfFile
-   import numpy as np
+   >>> from asdf import AsdfFile
+   >>> import numpy as np
 
-   my_array = np.random.rand(8, 8)
-   subset = my_array[2:4,3:6]
-   tree = {
-       'my_array': my_array,
-       'subset':   subset
-   }
-   ff = AsdfFile(tree)
-   ff.write_to("array_with_subset.asdf")
+   >>> my_array = np.random.rand(8, 8)
+   >>> subset = my_array[2:4,3:6]
+   >>> tree = {
+   ...     'my_array': my_array,
+   ...     'subset':   subset
+   ... }
+   >>> ff = AsdfFile(tree)
+   >>> ff.write_to("array_with_subset.asdf")
 
 For circumstances where this is undesirable (such as saving
 a small view of a large array) this can be disabled by setting
@@ -65,7 +84,35 @@ a small view of a large array) this can be disabled by setting
 or `asdf.AsdfFile.set_array_save_base` to control the behavior for
 a specific array.
 
-.. asdf:: array_with_subset.asdf
+.. code:: yaml
+
+   #ASDF 1.0.0
+   #ASDF_STANDARD 1.6.0
+   %YAML 1.1
+   %TAG ! tag:stsci.edu:asdf/
+   --- !core/asdf-1.1.0
+   asdf_library: !core/software-1.0.0 {author: The ASDF Developers, homepage: 'http://github.com/asdf-format/asdf',
+     name: asdf, version: 5.3.0}
+   history:
+     extensions:
+     - !core/extension_metadata-1.0.0
+       extension_class: asdf.extension._manifest.ManifestExtension
+       extension_uri: asdf://asdf-format.org/core/extensions/core-1.6.0
+       manifest_software: !core/software-1.0.0 {name: asdf_standard, version: 1.5.0}
+       software: !core/software-1.0.0 {name: asdf, version: 5.3.0}
+   my_array: !core/ndarray-1.1.0
+     source: 0
+     datatype: float64
+     byteorder: little
+     shape: [8, 8]
+   subset: !core/ndarray-1.1.0
+     source: 0
+     datatype: float64
+     byteorder: little
+     shape: [2, 3]
+     offset: 152
+     strides: [64, 8]
+   ...
 
 Saving inline arrays
 ====================
@@ -84,18 +131,54 @@ storage type of the associated data. The allowed values are ``internal``,
 
 - ``inline``: Store the data as YAML inline in the tree.
 
-.. runcode::
+.. code:: python
 
-   from asdf import AsdfFile
-   import numpy as np
+   >>> from asdf import AsdfFile
+   >>> import numpy as np
 
-   my_array = np.random.rand(8, 8)
-   tree = {'my_array': my_array}
-   ff = AsdfFile(tree)
-   ff.set_array_storage(my_array, 'inline')
-   ff.write_to("inline_array.asdf")
+   >>> my_array = np.random.rand(8, 8)
+   >>> tree = {'my_array': my_array}
+   >>> ff = AsdfFile(tree)
+   >>> ff.set_array_storage(my_array, 'inline')
+   >>> ff.write_to("inline_array.asdf")
 
-.. asdf:: inline_array.asdf
+.. code:: yaml
+
+   #ASDF 1.0.0
+   #ASDF_STANDARD 1.6.0
+   %YAML 1.1
+   %TAG ! tag:stsci.edu:asdf/
+   --- !core/asdf-1.1.0
+   asdf_library: !core/software-1.0.0 {author: The ASDF Developers, homepage: 'http://github.com/asdf-format/asdf',
+     name: asdf, version: 5.3.0}
+   history:
+     extensions:
+     - !core/extension_metadata-1.0.0
+       extension_class: asdf.extension._manifest.ManifestExtension
+       extension_uri: asdf://asdf-format.org/core/extensions/core-1.6.0
+       manifest_software: !core/software-1.0.0 {name: asdf_standard, version: 1.5.0}
+       software: !core/software-1.0.0 {name: asdf, version: 5.3.0}
+   my_array: !core/ndarray-1.1.0
+     data:
+     - [0.37364029001505683, 0.32162730726994515, 0.5174687024953414, 0.6819358522124768,
+       0.31545084462136797, 0.45336717886535716, 0.8766200166261489, 0.5351125807423055]
+     - [0.21313738755058198, 0.08678080629794094, 0.262603440816942, 0.08050589478748083,
+       0.137419316524092, 0.57123203453451, 0.40074196097349324, 0.849757947165214]
+     - [0.23667849260250273, 0.024930741318300198, 0.9758526963943653, 0.03298431078548114,
+       0.31662774377786995, 0.68377308750848, 0.790290072359762, 0.5050720750955217]
+     - [0.7378502143845163, 0.8893229877547028, 0.5351249751905818, 0.0022624182357939837,
+       0.7506228371871324, 0.9551597691023826, 0.1693896122914036, 0.8246100314570424]
+     - [0.647505181978522, 0.33308226013000286, 0.8135005179839472, 0.8404212344059925,
+       0.1562139195022587, 0.13503673673258954, 0.5874265747778596, 0.8032211348819358]
+     - [0.42912361221963025, 0.12376484161537937, 0.650502918744316, 0.4687943836977091,
+       0.38574705081654814, 0.195267928717743, 0.16493413972136817, 0.6627050583885223]
+     - [0.4327563083511644, 0.7236790063915097, 0.22216584584793642, 0.10166807219644336,
+       0.33464193496267347, 0.6941406199202252, 0.6329950377636102, 0.07729054807086944]
+     - [0.12793926460863403, 0.9588116248796417, 0.2001139992410388, 0.48143125131473163,
+       0.47964972042078724, 0.12156604005269112, 0.23365466431734938, 0.7703204892145835]
+     datatype: float64
+     shape: [8, 8]
+   ...
 
 Alternatively, it is possible to use the ``all_array_storage`` parameter of
 `AsdfFile.write_to` and `AsdfFile.update` to control the storage
@@ -139,25 +222,44 @@ Exploded form is useful in the following scenarios:
 To save a block in an external file, set its block type to
 ``'external'``.
 
-.. runcode::
+.. code:: python
 
-   from asdf import AsdfFile
-   import numpy as np
+   >>> from asdf import AsdfFile
+   >>> import numpy as np
 
-   my_array = np.random.rand(8, 8)
-   tree = {'my_array': my_array}
-   ff = AsdfFile(tree)
+   >>> my_array = np.random.rand(8, 8)
+   >>> tree = {'my_array': my_array}
+   >>> ff = AsdfFile(tree)
 
-   # On an individual block basis:
-   ff.set_array_storage(my_array, 'external')
-   ff.write_to("external.asdf")
+   >>> # On an individual block basis:
+   >>> ff.set_array_storage(my_array, 'external')
+   >>> ff.write_to("external.asdf")
 
-   # Or for every block:
-   ff.write_to("external.asdf", all_array_storage='external')
+   >>> # Or for every block:
+   >>> ff.write_to("external.asdf", all_array_storage='external')
 
-.. asdf:: external.asdf
+.. code:: yaml
 
-.. asdf:: external0000.asdf
+   #ASDF 1.0.0
+   #ASDF_STANDARD 1.6.0
+   %YAML 1.1
+   %TAG ! tag:stsci.edu:asdf/
+   --- !core/asdf-1.1.0
+   asdf_library: !core/software-1.0.0 {author: The ASDF Developers, homepage: 'http://github.com/asdf-format/asdf',
+     name: asdf, version: 5.3.0}
+   history:
+     extensions:
+     - !core/extension_metadata-1.0.0
+       extension_class: asdf.extension._manifest.ManifestExtension
+       extension_uri: asdf://asdf-format.org/core/extensions/core-1.6.0
+       manifest_software: !core/software-1.0.0 {name: asdf_standard, version: 1.5.0}
+       software: !core/software-1.0.0 {name: asdf, version: 5.3.0}
+   my_array: !core/ndarray-1.1.0
+     source: external0000.asdf
+     datatype: float64
+     byteorder: little
+     shape: [8, 8]
+   ...
 
 Streaming array data
 ====================
@@ -177,27 +279,48 @@ of the streamed data, but will not write out the actual content.  The
 file handle's ``write`` method is then used to manually write out the
 binary data.
 
-.. runcode::
+.. code:: python
 
-   from asdf import AsdfFile
-   from asdf.tags.core import Stream
-   import numpy as np
+   >>> from asdf import AsdfFile
+   >>> from asdf.tags.core import Stream
+   >>> import numpy as np
 
-   tree = {
-       # Each "row" of data will have 128 entries.
-       'my_stream': Stream([128], np.float64)
-   }
+   >>> tree = {
+   ...     # Each "row" of data will have 128 entries.
+   ...     'my_stream': Stream([128], np.float64)
+   ... }
 
-   ff = AsdfFile(tree)
-   with open('stream.asdf', 'wb') as fd:
-       ff.write_to(fd)
-       # Write 100 rows of data, one row at a time.  ``write``
-       # expects the raw binary bytes, not an array, so we use
-       # ``tobytes()``.
-       for i in range(100):
-           fd.write(np.array([i] * 128, np.float64).tobytes())
+   >>> ff = AsdfFile(tree)
+   >>> with open('stream.asdf', 'wb') as fd:  # doctest: +SKIP
+   ...     ff.write_to(fd)
+   ...     # Write 100 rows of data, one row at a time.  ``write``
+   ...     # expects the raw binary bytes, not an array, so we use
+   ...     # ``tobytes()``.
+   ...     for i in range(100):
+   ...         fd.write(np.array([i] * 128, np.float64).tobytes())
 
-.. asdf:: stream.asdf
+.. code:: yaml
+
+   #ASDF 1.0.0
+   #ASDF_STANDARD 1.6.0
+   %YAML 1.1
+   %TAG ! tag:stsci.edu:asdf/
+   --- !core/asdf-1.1.0
+   asdf_library: !core/software-1.0.0 {author: The ASDF Developers, homepage: 'http://github.com/asdf-format/asdf',
+     name: asdf, version: 5.3.0}
+   history:
+     extensions:
+     - !core/extension_metadata-1.0.0
+       extension_class: asdf.extension._manifest.ManifestExtension
+       extension_uri: asdf://asdf-format.org/core/extensions/core-1.6.0
+       manifest_software: !core/software-1.0.0 {name: asdf_standard, version: 1.5.0}
+       software: !core/software-1.0.0 {name: asdf, version: 5.3.0}
+   my_stream: !core/ndarray-1.1.0
+     source: -1
+     datatype: float64
+     byteorder: little
+     shape: ['*', 128]
+   ...
 
 When reading a file with a streamed block the streamed block will
 be treated as a normal non-streamed block. It may be useful to enable
@@ -257,21 +380,47 @@ are included in every asdf install. Passing one of these 4 character
 codes as ``all_array_compression`` to `asdf.AsdfFile.write_to` will
 compress all blocks with the corresponding algorithm:
 
-.. runcode::
+.. code:: python
 
-   from asdf import AsdfFile
-   import numpy as np
+   >>> from asdf import AsdfFile
+   >>> import numpy as np
 
-   tree = {
-       'a': np.random.rand(32, 32),
-       'b': np.random.rand(64, 64)
-   }
+   >>> tree = {
+   ...     'a': np.random.rand(32, 32),
+   ...     'b': np.random.rand(64, 64)
+   ... }
 
-   target = AsdfFile(tree)
-   target.write_to('target.asdf', all_array_compression='zlib')
-   target.write_to('target.asdf', all_array_compression='bzp2')
+   >>> target = AsdfFile(tree)
+   >>> target.write_to('target.asdf', all_array_compression='zlib')
+   >>> target.write_to('target.asdf', all_array_compression='bzp2')
 
-.. asdf:: target.asdf
+.. code:: yaml
+
+   #ASDF 1.0.0
+   #ASDF_STANDARD 1.6.0
+   %YAML 1.1
+   %TAG ! tag:stsci.edu:asdf/
+   --- !core/asdf-1.1.0
+   asdf_library: !core/software-1.0.0 {author: The ASDF Developers, homepage: 'http://github.com/asdf-format/asdf',
+     name: asdf, version: 5.3.0}
+   history:
+     extensions:
+     - !core/extension_metadata-1.0.0
+       extension_class: asdf.extension._manifest.ManifestExtension
+       extension_uri: asdf://asdf-format.org/core/extensions/core-1.6.0
+       manifest_software: !core/software-1.0.0 {name: asdf_standard, version: 1.5.0}
+       software: !core/software-1.0.0 {name: asdf, version: 5.3.0}
+   a: !core/ndarray-1.1.0
+     source: 0
+     datatype: float64
+     byteorder: little
+     shape: [32, 32]
+   b: !core/ndarray-1.1.0
+     source: 1
+     datatype: float64
+     byteorder: little
+     shape: [64, 64]
+   ...
 
 The `lz4 <https://en.wikipedia.org/wiki/LZ_4>`__ compression algorithm is also
 supported, but requires the optional

--- a/docs/asdf/extending/converters.rst
+++ b/docs/asdf/extending/converters.rst
@@ -419,44 +419,41 @@ accessed block during `Converter.from_yaml_tree` and `Converter.to_yaml_tree`.
 A simple example of a Converter using block storage to store the ``payload`` for
 ``BlockData`` object instances is as follows:
 
-.. runcode::
+.. code:: python
 
-    import asdf
-    import numpy as np
-    from asdf.extension import Converter, Extension
+   >>> import asdf
+   >>> import numpy as np
+   >>> from asdf.extension import Converter, Extension
 
-    class BlockData:
-        def __init__(self, payload):
-            self.payload = payload
+   >>> class BlockData:
+   ...     def __init__(self, payload):
+   ...         self.payload = payload
 
+   >>> class BlockConverter(Converter):
+   ...    tags = ["asdf://somewhere.org/tags/block_data-1.0.0"]
+   ...    types = [BlockData]
+   ...
+   ...    def to_yaml_tree(self, obj, tag, ctx):
+   ...        block_index = ctx.find_available_block_index(
+   ...            lambda: np.ndarray(len(obj.payload), dtype="uint8", buffer=obj.payload),
+   ...        )
+   ...        return {"block_index": block_index}
+   ...
+   ...    def from_yaml_tree(self, node, tag, ctx):
+   ...        block_index = node["block_index"]
+   ...        data_callback = ctx.get_block_data_callback(block_index)
+   ...        obj = BlockData(data_callback())
+   ...        return obj
 
-    class BlockConverter(Converter):
-        tags = ["asdf://somewhere.org/tags/block_data-1.0.0"]
-        types = [BlockData]
+   >>> class BlockExtension(Extension):
+   ...    tags = ["asdf://somewhere.org/tags/block_data-1.0.0"]
+   ...    converters = [BlockConverter()]
+   ...    extension_uri = "asdf://somewhere.org/extensions/block_data-1.0.0"
 
-        def to_yaml_tree(self, obj, tag, ctx):
-            block_index = ctx.find_available_block_index(
-                lambda: np.ndarray(len(obj.payload), dtype="uint8", buffer=obj.payload),
-            )
-            return {"block_index": block_index}
-
-        def from_yaml_tree(self, node, tag, ctx):
-            block_index = node["block_index"]
-            data_callback = ctx.get_block_data_callback(block_index)
-            obj = BlockData(data_callback())
-            return obj
-
-    class BlockExtension(Extension):
-        tags = ["asdf://somewhere.org/tags/block_data-1.0.0"]
-        converters = [BlockConverter()]
-        extension_uri = "asdf://somewhere.org/extensions/block_data-1.0.0"
-
-    with asdf.config_context() as cfg:
-        cfg.add_extension(BlockExtension())
-        ff = asdf.AsdfFile({"example": BlockData(b"abcdefg")})
-        ff.write_to("block_converter_example.asdf")
-
-.. asdf:: block_converter_example.asdf
+   >>> with asdf.config_context() as cfg:
+   ...    cfg.add_extension(BlockExtension())
+   ...    ff = asdf.AsdfFile({"example": BlockData(b"abcdefg")})
+   ...    ff.write_to("block_converter_example.asdf")
 
 During read, `Converter.from_yaml_tree` will be called. Within this method
 the Converter can prepare to access a block by calling
@@ -486,51 +483,49 @@ block it uses. These keys are generated using ``SerializationContext.generate_bl
 and must be stored by the extension code. These keys must be resupplied to the converter
 when writing an object that was read from an ASDF file.
 
-.. runcode::
+.. code:: python
 
-    import asdf
-    import numpy as np
-    from asdf.extension import Converter, Extension
+   >>> import asdf
+   >>> import numpy as np
+   >>> from asdf.extension import Converter, Extension
 
-    class MultiBlockData:
-        def __init__(self, data):
-            self.data = data
-            self.keys = []
-
-
-    class MultiBlockConverter(Converter):
-        tags = ["asdf://somewhere.org/tags/multi_block_data-1.0.0"]
-        types = [MultiBlockData]
-
-        def to_yaml_tree(self, obj, tag, ctx):
-            if not len(obj.keys):
-                obj.keys = [ctx.generate_block_key() for _ in obj.data]
-            indices = [ctx.find_available_block_index(d, k) for d, k in zip(obj.data, obj.keys)]
-            return {
-                "indices": indices,
-            }
-
-        def from_yaml_tree(self, node, tag, ctx):
-            indices = node["indices"]
-            keys = [ctx.generate_block_key() for _ in indices]
-            cbs = [ctx.get_block_data_callback(i, k) for i, k in zip(indices, keys)]
-            obj = MultiBlockData([cb() for cb in cbs])
-            obj.keys = keys
-            return obj
+   >>> class MultiBlockData:
+   ...     def __init__(self, data):
+   ...         self.data = data
+   ...         self.keys = []
 
 
-    class MultiBlockExtension(Extension):
-        tags = ["asdf://somewhere.org/tags/multi_block_data-1.0.0"]
-        converters = [MultiBlockConverter()]
-        extension_uri = "asdf://somewhere.org/extensions/multi_block_data-1.0.0"
+   >>> class MultiBlockConverter(Converter):
+   ...     tags = ["asdf://somewhere.org/tags/multi_block_data-1.0.0"]
+   ...     types = [MultiBlockData]
+   ...
+   ...     def to_yaml_tree(self, obj, tag, ctx):
+   ...         if not len(obj.keys):
+   ...             obj.keys = [ctx.generate_block_key() for _ in obj.data]
+   ...         indices = [ctx.find_available_block_index(d, k) for d, k in zip(obj.data, obj.keys)]
+   ...         return {
+   ...             "indices": indices,
+   ...         }
+   ...
+   ...     def from_yaml_tree(self, node, tag, ctx):
+   ...         indices = node["indices"]
+   ...         keys = [ctx.generate_block_key() for _ in indices]
+   ...         cbs = [ctx.get_block_data_callback(i, k) for i, k in zip(indices, keys)]
+   ...         obj = MultiBlockData([cb() for cb in cbs])
+   ...         obj.keys = keys
+   ...         return obj
 
-    with asdf.config_context() as cfg:
-        cfg.add_extension(MultiBlockExtension())
-        obj = MultiBlockData([np.arange(3, dtype="uint8") + i for i in range(3)])
-        ff = asdf.AsdfFile({"example": obj})
-        ff.write_to("multi_block_converter_example.asdf")
 
-.. asdf:: multi_block_converter_example.asdf
+   >>> class MultiBlockExtension(Extension):
+   ...     tags = ["asdf://somewhere.org/tags/multi_block_data-1.0.0"]
+   ...     converters = [MultiBlockConverter()]
+   ...     extension_uri = "asdf://somewhere.org/extensions/multi_block_data-1.0.0"
+
+   >>> with asdf.config_context() as cfg:
+   ...     cfg.add_extension(MultiBlockExtension())
+   ...     obj = MultiBlockData([np.arange(3, dtype="uint8") + i for i in range(3)])
+   ...     ff = asdf.AsdfFile({"example": obj})
+   ...     ff.write_to("multi_block_converter_example.asdf")
 
 .. _extending_converters_performance:
 

--- a/docs/asdf/features.rst
+++ b/docs/asdf/features.rst
@@ -250,21 +250,46 @@ of `asdf` can largely ignore that.
 
 First, we'll create a ASDF file with a couple of arrays in it:
 
-.. runcode::
+.. code:: python
 
-   import asdf
-   from asdf import AsdfFile
-   import numpy as np
+   >>> from asdf import AsdfFile
+   >>> import numpy as np
 
-   tree = {
-       'a': np.arange(0, 10),
-       'b': np.arange(10, 20)
-   }
+   >>> tree = {
+   ...     'a': np.arange(0, 10),
+   ...     'b': np.arange(10, 20)
+   ... }
 
-   target = AsdfFile(tree)
-   target.write_to('target.asdf')
+   >>> target = AsdfFile(tree)
+   >>> target.write_to("target.asdf")
 
-.. asdf:: target.asdf
+.. code:: yaml
+
+   #ASDF 1.0.0
+   #ASDF_STANDARD 1.6.0
+   %YAML 1.1
+   %TAG ! tag:stsci.edu:asdf/
+   --- !core/asdf-1.1.0
+   asdf_library: !core/software-1.0.0 {author: The ASDF Developers, homepage: 'http://github.com/asdf-format/asdf',
+     name: asdf, version: 5.3.0}
+   history:
+     extensions:
+     - !core/extension_metadata-1.0.0
+       extension_class: asdf.extension._manifest.ManifestExtension
+       extension_uri: asdf://asdf-format.org/core/extensions/core-1.6.0
+       manifest_software: !core/software-1.0.0 {name: asdf_standard, version: 1.5.0}
+       software: !core/software-1.0.0 {name: asdf, version: 5.3.0}
+   a: !core/ndarray-1.1.0
+     source: 0
+     datatype: int64
+     byteorder: little
+     shape: [10]
+   b: !core/ndarray-1.1.0
+     source: 1
+     datatype: int64
+     byteorder: little
+     shape: [10]
+   ...
 
 Then we will reference those arrays in a couple of different ways.
 First, we'll load the source file in Python and use the
@@ -273,42 +298,88 @@ Second, we'll work at the lower level by manually writing a JSON
 Pointer to array ``b``, which doesn't require loading or having access
 to the target file.
 
-.. runcode::
+.. code:: python
 
-   ff = AsdfFile()
+   >>> import asdf
+   >>> from asdf import AsdfFile
+   >>> ff = AsdfFile()
 
-   with asdf.open('target.asdf') as target:
-       ff.tree['my_ref_a'] = target.make_reference(['a'])
+   >>> with asdf.open('target.asdf') as target:
+   ...     ff.tree['my_ref_a'] = target.make_reference(['a'])
 
-   ff.tree['my_ref_b'] = {'$ref': 'target.asdf#b'}
+   >>> ff.tree['my_ref_b'] = {'$ref': 'target.asdf#b'}
+   >>> ff.write_to("source.asdf")
 
-   ff.write_to('source.asdf')
+.. code:: yaml
 
-.. asdf:: source.asdf
+   #ASDF 1.0.0
+   #ASDF_STANDARD 1.6.0
+   %YAML 1.1
+   %TAG ! tag:stsci.edu:asdf/
+   --- !core/asdf-1.1.0
+   asdf_library: !core/software-1.0.0 {author: The ASDF Developers, homepage: 'http://github.com/asdf-format/asdf',
+     name: asdf, version: 5.3.0}
+   history:
+     extensions:
+     - !core/extension_metadata-1.0.0
+       extension_class: asdf.extension._manifest.ManifestExtension
+       extension_uri: asdf://asdf-format.org/core/extensions/core-1.6.0
+       manifest_software: !core/software-1.0.0 {name: asdf_standard, version: 1.5.0}
+       software: !core/software-1.0.0 {name: asdf, version: 5.3.0}
+   my_ref_a: {$ref: target.asdf#a}
+   my_ref_b: {$ref: target.asdf#b}
+   ...
 
 Calling `~asdf.AsdfFile.find_references` will look up all of the
 references so they can be used as if they were local to the tree.  It
 doesn't actually move any of the data, and keeps the references as
 references.
 
-.. runcode::
+.. code:: python
 
-   with asdf.open('source.asdf') as ff:
-       ff.find_references()
-       assert ff.tree['my_ref_b'].shape == (10,)
+   >>> import asdf
+   >>> with asdf.open('source.asdf') as ff:
+   ...    ff.find_references()
+   ...    assert ff.tree['my_ref_b'].shape == (10,)
 
 On the other hand, calling `~asdf.AsdfFile.resolve_references`
 places all of the referenced content directly in the tree, so when we
 write it out again, all of the external references are gone, with the
 literal content in its place.
 
-.. runcode::
+.. code:: python
 
-   with asdf.open('source.asdf') as ff:
-       ff.resolve_references()
-       ff.write_to('resolved.asdf')
+   >>> import asdf
+   >>> with asdf.open('source.asdf') as ff:
+   ...    ff.resolve_references()
 
-.. asdf:: resolved.asdf
+.. code:: yaml
+
+   #ASDF 1.0.0
+   #ASDF_STANDARD 1.6.0
+   %YAML 1.1
+   %TAG ! tag:stsci.edu:asdf/
+   --- !core/asdf-1.1.0
+   asdf_library: !core/software-1.0.0 {author: The ASDF Developers, homepage: 'http://github.com/asdf-format/asdf',
+     name: asdf, version: 5.3.0}
+   history:
+     extensions:
+     - !core/extension_metadata-1.0.0
+       extension_class: asdf.extension._manifest.ManifestExtension
+       extension_uri: asdf://asdf-format.org/core/extensions/core-1.6.0
+       manifest_software: !core/software-1.0.0 {name: asdf_standard, version: 1.5.0}
+       software: !core/software-1.0.0 {name: asdf, version: 5.3.0}
+   my_ref_a: !core/ndarray-1.1.0
+     source: 0
+     datatype: int64
+     byteorder: little
+     shape: [10]
+   my_ref_b: !core/ndarray-1.1.0
+     source: 1
+     datatype: int64
+     byteorder: little
+     shape: [10]
+   ...
 
 A similar feature provided by YAML, anchors and aliases, also provides
 a way to support references within the same file.  These are supported
@@ -323,16 +394,35 @@ Anchors and aliases are handled automatically by `asdf` when the
 data structure is recursive.  For example here is a dictionary that is
 included twice in the same tree:
 
-.. runcode::
+.. code:: python
 
-    d = {'foo': 'bar'}
-    d['baz'] = d
-    tree = {'d': d}
+   >>> from asdf import AsdfFile
+   >>> d = {'foo': 'bar'}
+   >>> d['baz'] = d
+   >>> tree = {'d': d}
 
-    ff = AsdfFile(tree)
-    ff.write_to('anchors.asdf')
+   >>> ff = AsdfFile(tree)
 
-.. asdf:: anchors.asdf
+.. code:: yaml
+
+   #ASDF 1.0.0
+   #ASDF_STANDARD 1.6.0
+   %YAML 1.1
+   %TAG ! tag:stsci.edu:asdf/
+   --- !core/asdf-1.1.0
+   asdf_library: !core/software-1.0.0 {author: The ASDF Developers, homepage: 'http://github.com/asdf-format/asdf',
+     name: asdf, version: 5.3.0}
+   history:
+     extensions:
+     - !core/extension_metadata-1.0.0
+       extension_class: asdf.extension._manifest.ManifestExtension
+       extension_uri: asdf://asdf-format.org/core/extensions/core-1.6.0
+       manifest_software: !core/software-1.0.0 {name: asdf_standard, version: 1.5.0}
+       software: !core/software-1.0.0 {name: asdf, version: 5.3.0}
+   d: &id001
+     baz: *id001
+     foo: bar
+   ...
 
 .. _array-references:
 
@@ -371,19 +461,39 @@ As an example, we will create a reference to an external CSV file. We will
 assume that one of the rows of the CSV file contains the array data we care
 about:
 
-.. runcode::
+.. code::
 
-    import asdf
+   >>> import asdf
 
-    csv_data_row = 10 # The row of the CSV file containing the data we want
-    csv_row_size = 100 # The size of the array
-    extref = asdf.ExternalArrayReference('data.csv', csv_data_row, "int64", (csv_row_size,))
+   >>> csv_data_row = 10 # The row of the CSV file containing the data we want
+   >>> csv_row_size = 100 # The size of the array
+   >>> extref = asdf.ExternalArrayReference('data.csv', csv_data_row, "int64", (csv_row_size,))
 
-    tree = {'csv_data': extref}
-    af = asdf.AsdfFile(tree)
-    af.write_to('external_array.asdf')
+   >>> tree = {'csv_data': extref}
+   >>> af = asdf.AsdfFile(tree)
 
-.. asdf:: external_array.asdf
+.. code:: yaml
+
+   #ASDF 1.0.0
+   #ASDF_STANDARD 1.6.0
+   %YAML 1.1
+   %TAG ! tag:stsci.edu:asdf/
+   --- !core/asdf-1.1.0
+   asdf_library: !core/software-1.0.0 {author: The ASDF Developers, homepage: 'http://github.com/asdf-format/asdf',
+     name: asdf, version: 5.3.0}
+   history:
+     extensions:
+     - !core/extension_metadata-1.0.0
+       extension_class: asdf.extension._manifest.ManifestExtension
+       extension_uri: asdf://asdf-format.org/core/extensions/core-1.6.0
+       manifest_software: !core/software-1.0.0 {name: asdf_standard, version: 1.5.0}
+       software: !core/software-1.0.0 {name: asdf, version: 5.3.0}
+   csv_data: !core/externalarray-1.0.0
+     datatype: int64
+     fileuri: data.csv
+     shape: [100]
+     target: 10
+   ...
 
 When reading a file containing external references, the user is responsible for
 using the information in the `ExternalArrayReference` type to open the external
@@ -399,25 +509,51 @@ Given a `~asdf.AsdfFile` object, call `~asdf.AsdfFile.add_history_entry`, given
 a description of the change and optionally a description of the software (i.e.
 your software, not `asdf`) that performed the operation.
 
-.. runcode::
+.. code:: python
 
-   from asdf import AsdfFile
-   import numpy as np
+   >>> from asdf import AsdfFile
+   >>> import numpy as np
 
-   tree = {
-       'a': np.random.rand(32, 32)
-   }
+   >>> tree = {
+   ...    'a': np.random.rand(32, 32)
+   ... }
 
-   ff = AsdfFile(tree)
-   ff.add_history_entry(
-       "Initial random numbers",
-       {'name': 'asdf examples',
-        'author': 'John Q. Public',
-        'homepage': 'http://github.com/asdf-format/asdf',
-        'version': '0.1'})
-   ff.write_to('example.asdf')
+   >>> ff = AsdfFile(tree)
+   >>> ff.add_history_entry(
+   ...    "Initial random numbers",
+   ...    {'name': 'asdf examples',
+   ...     'author': 'John Q. Public',
+   ...     'homepage': 'http://github.com/asdf-format/asdf',
+   ...     'version': '0.1'})
 
-.. asdf:: example.asdf
+.. code:: yaml
+
+   #ASDF 1.0.0
+   #ASDF_STANDARD 1.6.0
+   %YAML 1.1
+   %TAG ! tag:stsci.edu:asdf/
+   --- !core/asdf-1.1.0
+   asdf_library: !core/software-1.0.0 {author: The ASDF Developers, homepage: 'http://github.com/asdf-format/asdf',
+     name: asdf, version: 5.3.0}
+   history:
+     entries:
+     - !core/history_entry-1.0.0
+       description: Initial random numbers
+       software: !core/software-1.0.0 {author: John Q. Public, homepage: 'http://github.com/asdf-format/asdf',
+         name: asdf examples, version: '0.1'}
+       time: 2026-06-01 16:19:08+00:00
+     extensions:
+     - !core/extension_metadata-1.0.0
+       extension_class: asdf.extension._manifest.ManifestExtension
+       extension_uri: asdf://asdf-format.org/core/extensions/core-1.6.0
+       manifest_software: !core/software-1.0.0 {name: asdf_standard, version: 1.5.0}
+       software: !core/software-1.0.0 {name: asdf, version: 5.3.0}
+   a: !core/ndarray-1.1.0
+     source: 0
+     datatype: float64
+     byteorder: little
+     shape: [32, 32]
+   ...
 
 `asdf` automatically saves history metadata about the extensions that were used
 to create the file. This information is used when opening files to determine if

--- a/docs/asdf/overview.rst
+++ b/docs/asdf/overview.rst
@@ -19,55 +19,81 @@ Hello World
 At its core, ASDF is a way of saving nested data structures to YAML.  Here we
 save a :class:`dict` with the key/value pair ``'hello': 'world'``.
 
-.. runcode::
+.. code:: python
 
-   from asdf import AsdfFile
+   >>> from asdf import AsdfFile
 
-   # Make the tree structure, and create a AsdfFile from it.
-   tree = {'hello': 'world'}
-   ff = AsdfFile(tree)
-   ff.write_to("test.asdf")
+   >>> # Make the tree structure, and create a AsdfFile from it.
+   >>> tree = {'hello': 'world'}
+   >>> ff = AsdfFile(tree)
+   >>> ff.write_to("test.asdf")
 
-   # You can also make the AsdfFile first, and modify its tree directly:
-   ff = AsdfFile()
-   ff.tree['hello'] = 'world'
-   ff.write_to("test.asdf")
+   >>> # You can also make the AsdfFile first, and modify its tree directly:
+   >>> ff = AsdfFile()
+   >>> ff.tree['hello'] = 'world'
+   >>> ff.write_to("test.asdf")
 
-.. asdf:: test.asdf
+.. code:: yaml
+
+   #ASDF 1.0.0
+   #ASDF_STANDARD 1.6.0
+   %YAML 1.1
+   %TAG ! tag:stsci.edu:asdf/
+   --- !core/asdf-1.1.0
+   asdf_library: !core/software-1.0.0 {author: The ASDF Developers, homepage: 'http://github.com/asdf-format/asdf',
+     name: asdf, version: 5.3.0}
+   history:
+     extensions:
+     - !core/extension_metadata-1.0.0
+       extension_class: asdf.extension._manifest.ManifestExtension
+       extension_uri: asdf://asdf-format.org/core/extensions/core-1.6.0
+       manifest_software: !core/software-1.0.0 {name: asdf_standard, version: 1.5.0}
+       software: !core/software-1.0.0 {name: asdf, version: 5.3.0}
+   hello: world
+   ...
 
 Creating Files
 ==============
-
-.. runcode:: hidden
-
-    import asdf
-    import numpy as np
-
-    # Create some data
-    sequence = np.arange(100)
-    squares  = sequence**2
-    random = np.random.random(100)
-
-    # Store the data in an arbitrarily nested dictionary
-    tree = {
-        'foo': 42,
-        'name': 'Monty',
-        'sequence': sequence,
-        'powers': { 'squares' : squares },
-        'random': random
-    }
-
-    # Create the ASDF file object from our data tree
-    af = asdf.AsdfFile(tree)
-
-    # Write the data to a new file
-    af.write_to('example.asdf')
 
 .. include:: ../../README.rst
     :start-after: begin-create-file-text:
     :end-before: begin-example-asdf-metadata:
 
-.. asdf:: example.asdf no_blocks
+.. code:: yaml
+
+   #ASDF 1.0.0
+   #ASDF_STANDARD 1.6.0
+   %YAML 1.1
+   %TAG ! tag:stsci.edu:asdf/
+   --- !core/asdf-1.1.0
+   asdf_library: !core/software-1.0.0 {author: The ASDF Developers, homepage: 'http://github.com/asdf-format/asdf',
+     name: asdf, version: 5.3.0}
+   history:
+     extensions:
+     - !core/extension_metadata-1.0.0
+       extension_class: asdf.extension._manifest.ManifestExtension
+       extension_uri: asdf://asdf-format.org/core/extensions/core-1.6.0
+       manifest_software: !core/software-1.0.0 {name: asdf_standard, version: 1.5.0}
+       software: !core/software-1.0.0 {name: asdf, version: 5.3.0}
+   foo: 42
+   name: Monty
+   powers:
+     squares: !core/ndarray-1.1.0
+       source: 1
+       datatype: int64
+       byteorder: little
+       shape: [100]
+   random: !core/ndarray-1.1.0
+     source: 2
+     datatype: float64
+     byteorder: little
+     shape: [100]
+   sequence: !core/ndarray-1.1.0
+     source: 0
+     datatype: int64
+     byteorder: little
+     shape: [100]
+   ...
 
 .. include:: ../../README.rst
     :start-after: end-example-asdf-metadata:
@@ -76,8 +102,6 @@ Creating Files
 A rendering of the binary data contained in the file can be found below. Observe that
 the value of ``source`` in the metadata corresponds to the block number (e.g. ``BLOCK 0``)
 of the block which contains the binary data.
-
-.. asdf:: example.asdf no_header
 
 .. include:: ../../README.rst
     :start-after: _begin-compress-file:

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -1,1 +1,15 @@
+import os
+
+import pytest
+
 collect_ignore = ["conf.py"]
+
+@pytest.fixture(autouse=True)
+def tmp_cwd(tmp_path):
+    """Run doctests in a temporary directory."""
+    curdir = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        yield
+    finally:
+        os.chdir(curdir)

--- a/integration_tests/compatibility/test_file_compatibility.py
+++ b/integration_tests/compatibility/test_file_compatibility.py
@@ -199,7 +199,10 @@ def test_file_compatibility(asdf_version, env_path, tmp_path):
                 str(standard_version),
                 capture_output=True,
             ), f"asdf library version {asdf_version} failed to generate an ASDF Standard {standard_version} file"
-            assert_file_correct(old_file_path), (
-                f"asdf library version {asdf_version} produced an ASDF Standard {standard_version}"
-                "that this code failed to read"
+            (
+                assert_file_correct(old_file_path),
+                (
+                    f"asdf library version {asdf_version} produced an ASDF Standard {standard_version}"
+                    "that this code failed to read"
+                ),
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,6 +156,10 @@ target-version = "py310"
 line-length = 120
 extend-exclude = ["asdf/_extern/*", "asdf/_jsonschema/*", "docs/*"]
 
+[tool.ruff.format]
+docstring-code-format = true
+docstring-code-line-length = 88
+
 [tool.ruff.lint]
 select = [
   # minimal set to match pre-ruff behavior

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -204,3 +204,9 @@ issue_format = "`#{issue} <https://github.com/asdf-format/asdf/pull/{issue}>`_"
 [tool.towncrier.fragment.removal]
 
 [tool.towncrier.fragment.general]
+
+# Disable automatic table sorting for pyproject.toml
+[[tool.tombi.schemas]]
+path = "tombi://www.schemastore.org/pyproject.json"
+include = ["pyproject.toml"]
+format.rules.table-keys-order.enabled = false

--- a/tox.ini
+++ b/tox.ini
@@ -321,6 +321,21 @@ commands_pre =
 commands =
     pytest --benchmark-skip
 
+[testenv:dkist-inventory]
+change_dir = {env_tmp_dir}
+allowlist_externals =
+    git
+    bash
+extras =
+commands_pre =
+    git clone https://bitbucket.org/dkistdc/dkist-inventory.git .
+    bash -c "pip freeze -q | grep 'asdf @' > {env_tmp_dir}/asdf_requirement.txt"
+    pip install -e ".[test]"
+    pip install -r {env_tmp_dir}/asdf_requirement.txt
+    pip freeze
+commands =
+    pytest -n auto
+
 [testenv:abacusutils]
 change_dir = {env_tmp_dir}
 allowlist_externals =


### PR DESCRIPTION
Update 5.3.x branch with add_history_entry fix for 5.3.1 release #2044

To appease pre-commit and the docs also had to backport:
- https://github.com/asdf-format/asdf/pull/2057
- https://github.com/asdf-format/asdf/pull/2042
- https://github.com/asdf-format/asdf/pull/2033

Will need to forward port the changelog after this is merged.

## Tasks

- [ ] [run `prek` on your machine](https://prek.j178.dev/quickstart/)
- [ ] run `pytest` on your machine
- [ ] Does this PR add new features and / or change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
    - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
    - [ ] update relevant docstrings and / or `docs/` page
    - [ ] for any new features, add unit tests

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: bug fix
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
