### PR TITLE
forward port: render changelog for 5.3.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,13 @@
+5.3.1 (2026-06-08)
+==================
+
+Bugfix
+------
+
+- Fix bug where ``add_history_entry`` incorrectly used a custom schema if
+  available. (`#2044 <https://github.com/asdf-format/asdf/pull/2044>`_)
+
+
 5.3.0 (2026-04-23)
 ==================
 

--- a/changes/2044.bugfix.rst
+++ b/changes/2044.bugfix.rst
@@ -1,1 +1,0 @@
-Fix bug where ``add_history_entry`` incorrectly used a custom schema if available.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ exclude = ["asdf/_jsonschema/json/*"]
 
 [tool.setuptools_scm]
 version_file = "asdf/_version.py"
+version_scheme = "release-branch-semver"
 
 [tool.black]
 line-length = 120


### PR DESCRIPTION
Update changelog on main for 5.3.1 release.

## Tasks

- [ ] [run `prek` on your machine](https://prek.j178.dev/quickstart/)
- [ ] run `pytest` on your machine
- [ ] Does this PR add new features and / or change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
    - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
    - [ ] update relevant docstrings and / or `docs/` page
    - [ ] for any new features, add unit tests

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: bug fix
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
