### PR TITLE
Fix failure to load files with untagged history metadata

### DIFF
--- a/asdf/_asdf.py
+++ b/asdf/_asdf.py
@@ -456,7 +456,8 @@ class AsdfFile:
                         version=resource_mapping.package_version,
                     )
 
-            for i, entry in enumerate(tree["history"]["extensions"]):
+            for i, ex in enumerate(tree["history"]["extensions"]):
+                entry = ExtensionMetadata(ex)
                 # Update metadata about this extension if it already exists
                 if (
                     entry.extension_uri is not None and entry.extension_uri == extension.extension_uri

--- a/asdf/_asdf.py
+++ b/asdf/_asdf.py
@@ -274,7 +274,10 @@ class AsdfFile:
         ):
             return
 
-        for extension in tree["history"]["extensions"]:
+        for ex in tree["history"]["extensions"]:
+            # Convert extension entries to `ExtensionMetadata` if needed
+            # Entries can be plain dictionaries if they don't have schema tags
+            extension = ExtensionMetadata(ex)
             installed = None
             for ext in self._user_extensions + self._plugin_extensions:
                 if (extension.extension_uri is not None and extension.extension_uri == ext.extension_uri) or (

--- a/asdf/_tests/test_history.py
+++ b/asdf/_tests/test_history.py
@@ -334,3 +334,5 @@ history:
 
     with asdf.open(BytesIO(file.encode())) as af:
         af.validate()
+
+        af.write_to(BytesIO())

--- a/asdf/_tests/test_history.py
+++ b/asdf/_tests/test_history.py
@@ -325,7 +325,7 @@ history:
       extension_uri: "asdf://asdf-format.org/core/extensions/core-1.6.0"
       manifest_software:
         name: "asdf_standard"
-        version: "1.1.1"
+        version: "1.1.0"
       software:
         name: "asdf"
         version: "4.1.0"

--- a/asdf/_tests/test_history.py
+++ b/asdf/_tests/test_history.py
@@ -334,5 +334,7 @@ history:
 
     with asdf.open(BytesIO(file.encode())) as af:
         af.validate()
+        # check that extensions entries remain untagged
+        assert type(af["history"]["extensions"][0]) is dict
 
         af.write_to(BytesIO())

--- a/asdf/_tests/test_history.py
+++ b/asdf/_tests/test_history.py
@@ -312,8 +312,8 @@ def test_history_ignores_custom_schema(tmp_path):
     assert af.get_history_entries()[0]["description"] == "test"
 
 
-def test_history_missing_schema_tag():
-    """Test that a file can be loaded and validated even if its extension list entries don't have schema tags."""
+def test_history_extensions_missing_tags():
+    """Test that a file can be loaded and validated even if its extension list entries don't have tags."""
     file = """#ASDF 1.0.0
 #ASDF_STANDARD 1.6.0
 %YAML 1.1

--- a/asdf/_tests/test_history.py
+++ b/asdf/_tests/test_history.py
@@ -1,6 +1,7 @@
 import datetime
 import fractions
 import warnings
+from io import BytesIO
 
 import pytest
 
@@ -309,3 +310,27 @@ def test_history_ignores_custom_schema(tmp_path):
 
     af.add_history_entry("test")
     assert af.get_history_entries()[0]["description"] == "test"
+
+
+def test_history_missing_schema_tag():
+    """Test that a file can be loaded and validated even if its extension list entries don't have schema tags."""
+    file = """#ASDF 1.0.0
+#ASDF_STANDARD 1.6.0
+%YAML 1.1
+%TAG ! tag:stsci.edu:asdf/
+--- !core/asdf-1.1.0
+history:
+  extensions:
+    - extension_class: "asdf.extension._manifest.ManifestExtension"
+      extension_uri: "asdf://asdf-format.org/core/extensions/core-1.6.0"
+      manifest_software:
+        name: "asdf_standard"
+        version: "1.1.1"
+      software:
+        name: "asdf"
+        version: "4.1.0"
+...
+    """
+
+    with asdf.open(BytesIO(file.encode())) as af:
+        af.validate()

--- a/changes/2068.bugfix.rst
+++ b/changes/2068.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed files failing to load if their history section contains extension entries without schema tags.

--- a/changes/2068.bugfix.rst
+++ b/changes/2068.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed files failing to load if their history section contains extension entries without schema tags.
+Fixed files failing to load if their history section contains extension entries without tags.


### PR DESCRIPTION
## Description
* Fixed files failing to load if their history section contains extension entries without schema tags

Closes #2063