### PR TITLE
Warn when writing replaces a user-set asdf_library

### DIFF
--- a/asdf/_asdf.py
+++ b/asdf/_asdf.py
@@ -807,12 +807,26 @@ class AsdfFile:
             padding = util.calculate_padding(fd.tell(), pad_blocks, fd.block_size)
             fd.fast_forward(padding)
 
+    def _warn_if_asdf_library_overwritten(self) -> None:
+        # "asdf_library" is reserved for the library version information
+        # generated at write time. A round-tripped file carries the
+        # ``Software`` written by the previous write, which is expected to
+        # be replaced silently; anything else was set by the user and would
+        # otherwise be discarded without feedback (#1921).
+        if "asdf_library" in self._tree and not isinstance(self._tree["asdf_library"], Software):
+            msg = (
+                "'asdf_library' is reserved for library version information; "
+                "the value in the tree will be replaced when writing"
+            )
+            warnings.warn(msg, AsdfWarning)
+
     def _serial_write(
         self, fd: GenericFile, pad_blocks: float | bool, include_block_index: bool, write_checksums: bool
     ) -> None:
         with self._blocks.write_context(fd):
             # prep a tree for a writing
             tree = copy.copy(self._tree)
+            self._warn_if_asdf_library_overwritten()
             tree["asdf_library"] = _io.get_asdf_library_info()
             if "history" in self._tree:
                 tree["history"] = copy.deepcopy(self._tree["history"])
@@ -936,6 +950,7 @@ class AsdfFile:
                 rewrite(fd)
                 return
 
+            self._warn_if_asdf_library_overwritten()
             self._tree["asdf_library"] = _io.get_asdf_library_info()
 
             # prepare block manager for writing

--- a/asdf/_tests/test_api.py
+++ b/asdf/_tests/test_api.py
@@ -12,7 +12,7 @@ from numpy.testing import assert_array_equal
 
 import asdf
 from asdf import config_context, get_config, treeutil, versioning
-from asdf.exceptions import AsdfPackageVersionWarning, ValidationError
+from asdf.exceptions import AsdfPackageVersionWarning, AsdfWarning, ValidationError
 from asdf.extension import ExtensionProxy
 from asdf.resource import ResourceMappingProxy
 from asdf.testing.helpers import roundtrip_object, yaml_to_asdf
@@ -554,6 +554,34 @@ def test_update_asdf_standard_version_tag_selection():
     content = buff.read()
     assert b"!core/asdf-1.1.0" in content
     assert b"!core/asdf-1.0.0" not in content
+
+
+def test_write_to_warns_when_replacing_user_set_asdf_library(tmp_path):
+    """A user-set 'asdf_library' is replaced at write time; warn instead of
+    discarding it silently (#1921)."""
+    af = asdf.AsdfFile()
+    af["asdf_library"] = 1
+    with pytest.warns(AsdfWarning, match="'asdf_library' is reserved"):
+        af.write_to(tmp_path / "test.asdf")
+
+
+def test_update_warns_when_replacing_user_set_asdf_library(tmp_path):
+    """update() replaces 'asdf_library' like write_to does (#1921)."""
+    fn = tmp_path / "test.asdf"
+    asdf.AsdfFile({"foo": "bar"}).write_to(fn)
+    with asdf.open(fn, mode="rw") as af:
+        af["asdf_library"] = {"name": "mylib"}
+        with pytest.warns(AsdfWarning, match="'asdf_library' is reserved"):
+            af.update()
+
+
+def test_round_trip_does_not_warn_for_asdf_library(tmp_path, recwarn):
+    """The 'asdf_library' read back from a file is replaced silently."""
+    fn = tmp_path / "test.asdf"
+    asdf.AsdfFile({"foo": "bar"}).write_to(fn)
+    with asdf.open(fn) as af:
+        af.write_to(tmp_path / "test2.asdf")
+    assert not any(isinstance(w.message, AsdfWarning) for w in recwarn.list)
 
 
 @pytest.mark.parametrize("valid_filename", [True, False], ids=["valid_filename", "invalid_filename"])

--- a/changes/2069.bugfix.rst
+++ b/changes/2069.bugfix.rst
@@ -1,0 +1,1 @@
+Warn with ``AsdfWarning`` when ``write_to`` or ``update`` replaces a user-set ``asdf_library`` in the tree.


### PR DESCRIPTION
Fixes #1921.

`write_to` and `update` unconditionally replace `tree["asdf_library"]` with the library version info, so a value the user set there is discarded with no feedback. This adds an `AsdfWarning` when the value about to be replaced is not a `Software` instance — the `Software` case is the normal round-trip of a previously written file (or the in-place edits exercised by `test_write_to_no_tree_modification`) and stays silent as before.

Tests cover both write paths plus the no-warning round-trip; verified red without the change.
