### PR TITLE
add 3.15 job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
         - linux: py313-coverage-devdeps-parallel
         - linux: py314-coverage-devdeps-parallel
         - linux: py315-coverage-pytestdev-parallel
-          python-version: 3.15-dev
+          python-version: 3.15
         # separate pytest so a failure here doesn't cause the whole suite to fail
         - linux: py314-coverage-pytestdev-parallel
       coverage: codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,6 @@ jobs:
     - run: pip install -e ".[all,tests,typing]"
     - run: pyrefly check --output-format=github
   core:
-    needs: [pre-commit]
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v2
     with:
       submodules: false
@@ -76,7 +75,6 @@ jobs:
           python-version: 3.12
 
   asdf-schemas:
-    needs: [core]
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v2
     with:
       submodules: false
@@ -87,7 +85,6 @@ jobs:
           python-version: 3.12
 
   test:
-    needs: [core]
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v2
     with:
       submodules: false
@@ -96,7 +93,6 @@ jobs:
         - windows: py311-parallel
 
   dev:
-    needs: [core]
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v2
     with:
       submodules: false
@@ -113,7 +109,6 @@ jobs:
       coverage: codecov
 
   oldest:
-    needs: [core]
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v2
     with:
       submodules: false
@@ -121,7 +116,6 @@ jobs:
         - linux: py310-oldestdeps-parallel
 
   compatibility:
-    needs: [core]
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v2
     with:
       submodules: false
@@ -130,7 +124,6 @@ jobs:
           python-version: 3.11
 
   mocks3:
-    needs: [core]
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v2
     with:
       submodules: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,8 @@ jobs:
         - linux: py312-coverage-devdeps-parallel
         - linux: py313-coverage-devdeps-parallel
         - linux: py314-coverage-devdeps-parallel
+        - linux: py315-coverage-pytestdev-parallel
+          python-version: 3.15-dev
         # separate pytest so a failure here doesn't cause the whole suite to fail
         - linux: py314-coverage-pytestdev-parallel
       coverage: codecov


### PR DESCRIPTION
## Description

Add a 3.15 CI job (with devdeps to pick up the dev numpy that supports 3.15).

Also fixes #2043 

All tests pass so looks like 3.15 support is good-to-go.

No LLMs were used for this PR.

## Tasks

- [ ] [run `prek` on your machine](https://prek.j178.dev/quickstart/)
- [ ] run `pytest` on your machine
- [ ] Does this PR add new features and / or change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
    - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
    - [ ] update relevant docstrings and / or `docs/` page
    - [ ] for any new features, add unit tests

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: bug fix
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
