### PR TITLE
Update PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,34 +1,26 @@
-<!---
+## Description
+<!--
 Thanks for contributing to asdf!
 
-Your PR should trigger the CI (after approval for first-time contributors)
-which will:
-
-- check your code for 'style' using prek
-- run your PR against the asdf unit tests for various OSes, python versions, and dependency versions
-- perform a test build of your PR
-
-It is highly recommended that you run some of these tests locally by:
-
-- [installing prek](https://prek.j178.dev/quickstart/)
-- [running pytest](https://docs.pytest.org/en/7.1.x/getting-started.html)
-
-This will increase the chances your PR will pass the required CI tests.
--->
-
-## Description
-
-<!--
 Please describe what this PR accomplishes.
 If the changes are non-obvious, please explain how they work.
 If this PR adds a new feature please include tests and documentation.
 If this PR fixes an issue, please add closing keywords (eg 'fixes #XXX')
 -->
 
+## AI Disclosure
+<!--
+If AI tools were used as part of development of this pull request, please describe which tools and the extent of their use.
+If no AI tools were used, please write "No AI tools used".
+
+All AI usage must comply with our AI policy:
+https://github.com/asdf-format/.github/blob/main/AI_POLICY.md
+-->
+
 ## Tasks
 
 - [ ] [run `prek` on your machine](https://prek.j178.dev/quickstart/)
-- [ ] run `pytest` on your machine
+- [ ] [run `pytest` on your machine](https://docs.pytest.org/en/7.1.x/getting-started.html)
 - [ ] Does this PR add new features and / or change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
     - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
     - [ ] update relevant docstrings and / or `docs/` page


### PR DESCRIPTION
## Description

* Updated local PR template to include changes from organization-level template

We could alternatively remove this template so that the repo can just inherit the org-level template, but having the specific guidance on changelog and CI seems helpful.