### PR TITLE
Fix structured inline arrays with zero-length dimensions failing to roundtrip

### DIFF
--- a/asdf/_tests/tags/core/tests/test_ndarray.py
+++ b/asdf/_tests/tags/core/tests/test_ndarray.py
@@ -1142,8 +1142,21 @@ def test_lazy_load_array_class(tmp_path, lazy_load, lazy_tree, array_class):
         (10, 0, 10, 0),
     ],
 )
-def test_empty_inline_array_roundtrip(shape):
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        np.float32,  # Basic scalar type
+        np.dtype([("x", "f4"), ("y", "<U10")]),  # 1-D structured type
+        np.dtype([("x", "f4")]),  # structured type with a single field
+        np.dtype([("x", [("a", "f4"), ("b", "<i8")]), ("y", "<U10")]),  # Nested structured type
+        # Just in case the nested field not being first matters for some reason
+        np.dtype([("y", "<U10"), ("x", [("a", "f4"), ("b", "<i8")])]),
+    ],
+)
+def test_empty_inline_array_roundtrip(shape, dtype):
     """Test that arrays with zero-length axes are round-tripped correctly"""
-    array = np.zeros(shape, dtype=np.float32)
+    array = np.empty(shape, dtype=dtype)
     f = asdf.loads(asdf.dumps({"array": array}, all_array_storage="inline"))
-    assert f["array"].shape == shape
+    # Can't just compare the arrays because numpy doesn't like comparing empty arrays
+    assert f["array"].shape == array.shape
+    assert f["array"].dtype == array.dtype

--- a/asdf/tags/core/ndarray.py
+++ b/asdf/tags/core/ndarray.py
@@ -156,7 +156,7 @@ def numpy_dtype_to_asdf_datatype(dtype, include_byteorder=True, override_byteord
     raise ValueError(msg)
 
 
-def inline_data_asarray(inline, dtype=None, shape=None):
+def inline_data_asarray(inline, dtype=None):
     # np.asarray doesn't handle structured arrays unless the innermost
     # elements are tuples.  To do that, we drill down the first
     # element of each level until we find a single item that

--- a/asdf/tags/core/ndarray.py
+++ b/asdf/tags/core/ndarray.py
@@ -156,7 +156,7 @@ def numpy_dtype_to_asdf_datatype(dtype, include_byteorder=True, override_byteord
     raise ValueError(msg)
 
 
-def inline_data_asarray(inline, dtype=None):
+def inline_data_asarray(inline, dtype=None, shape=None):
     # np.asarray doesn't handle structured arrays unless the innermost
     # elements are tuples.  To do that, we drill down the first
     # element of each level until we find a single item that
@@ -167,6 +167,12 @@ def inline_data_asarray(inline, dtype=None):
     # object dtypes, but ASDF explicitly excludes those, so we're ok
     # there.
     if dtype is not None and dtype.fields is not None:
+
+        def is_empty(arr):
+            if isinstance(arr, list):
+                return all(is_empty(x) for x in arr)
+
+            return False
 
         def find_innermost_match(line, depth=0):
             if not isinstance(line, list) or not len(line):
@@ -179,15 +185,15 @@ def inline_data_asarray(inline, dtype=None):
             else:
                 return depth
 
-        depth = find_innermost_match(inline)
-
         def convert_to_tuples(line, data_depth, depth=0):
             if data_depth == depth:
                 return tuple(line)
 
             return [convert_to_tuples(x, data_depth, depth + 1) for x in line]
 
-        inline = convert_to_tuples(inline, depth)
+        if not is_empty(inline):
+            depth = find_innermost_match(inline)
+            inline = convert_to_tuples(inline, depth)
 
         return np.asarray(inline, dtype=dtype)
 

--- a/changes/2083.bugfix.rst
+++ b/changes/2083.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed structured arrays with zero-length dimensions failing to round-trip correctly when saved inline.


### PR DESCRIPTION
## Description
* Fixed structured inline arrays with zero-length dimensions failing to roundtrip correctly
* Added new test cases to `test_empty_inline_array_roundtrip` to test structured arrays in addition to scalar dtypes

Closes #2074 

## AI Disclosure
No AI tools used

## Tasks

- [ ] [run `prek` on your machine](https://prek.j178.dev/quickstart/)
- [ ] [run `pytest` on your machine](https://docs.pytest.org/en/7.1.x/getting-started.html)
- [ ] Does this PR add new features and / or change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
    - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
    - [ ] update relevant docstrings and / or `docs/` page
    - [ ] for any new features, add unit tests

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: bug fix
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
