### PR TITLE
Add link to AI policy in `CONTRIBUTING.rst`

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -61,3 +61,8 @@ to the maintainers, who are glad to assist you.
     - ``doc``: documentation change
     - ``removal``: deprecation or removal of public API
     - ``general``: infrastructure or miscellaneous change
+
+AI Policy
+---------
+
+All contributions must conform to ASDF's `AI Policy <https://github.com/asdf-format/.github/blob/main/AI_POLICY.md>`_

--- a/changes/2088.doc.rst
+++ b/changes/2088.doc.rst
@@ -1,0 +1,1 @@
+Added link to AI policy in contributor guide.


### PR DESCRIPTION
## Description
* Added link to AI policy in `CONTRIBUTING.rst`

## AI Disclosure
No AI tools used

## Tasks

- [ ] [run `prek` on your machine](https://prek.j178.dev/quickstart/)
- [ ] [run `pytest` on your machine](https://docs.pytest.org/en/7.1.x/getting-started.html)
- [ ] Does this PR add new features and / or change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
    - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
    - [ ] update relevant docstrings and / or `docs/` page
    - [ ] for any new features, add unit tests

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: bug fix
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
