### PR TITLE
remove NOT_SET restore NotSet

### DIFF
--- a/asdf/_asdf.py
+++ b/asdf/_asdf.py
@@ -892,11 +892,11 @@ class AsdfFile:
 
         with config_context() as config:
             if all_array_storage is not NotSet:
-                config.all_array_storage = all_array_storage  # type: ignore
+                config.all_array_storage = typing.cast("ArrayStorage", all_array_storage)
             if all_array_compression is not NotSet:
-                config.all_array_compression = all_array_compression  # type: ignore
+                config.all_array_compression = typing.cast("Compression", all_array_compression)
             if compression_kwargs is not NotSet:
-                config.all_array_compression_kwargs = compression_kwargs  # type: ignore
+                config.all_array_compression_kwargs = typing.cast("dict", compression_kwargs)
 
             fd = self._fd
 
@@ -1069,11 +1069,11 @@ class AsdfFile:
         """
         with config_context() as config:
             if all_array_storage is not NotSet:
-                config.all_array_storage = all_array_storage  # type: ignore
+                config.all_array_storage = typing.cast("ArrayStorage", all_array_storage)
             if all_array_compression is not NotSet:
-                config.all_array_compression = all_array_compression  # type: ignore
+                config.all_array_compression = typing.cast("Compression", all_array_compression)
             if compression_kwargs is not NotSet:
-                config.all_array_compression_kwargs = compression_kwargs  # type: ignore
+                config.all_array_compression_kwargs = typing.cast("dict", compression_kwargs)
 
             previous_version = None
             if version is not None:

--- a/asdf/_asdf.py
+++ b/asdf/_asdf.py
@@ -47,6 +47,7 @@ if TYPE_CHECKING:
         FileMode,
         FilterFn,
         NDArray,
+        NotSetType,
         PathLike,
         TreeKey,
     )
@@ -825,9 +826,9 @@ class AsdfFile:
 
     def update(
         self,
-        all_array_storage: ArrayStorage | NotSet = NotSet,
-        all_array_compression: Compression | NotSet = NotSet,
-        compression_kwargs: dict[str, Any] | NotSet = NotSet,
+        all_array_storage: ArrayStorage | NotSetType = NotSet,
+        all_array_compression: Compression | NotSetType = NotSet,
+        compression_kwargs: dict[str, Any] | NotSetType = NotSet,
         pad_blocks: bool | float = False,
         include_block_index: bool = True,
         version: str | None = None,
@@ -891,11 +892,11 @@ class AsdfFile:
 
         with config_context() as config:
             if all_array_storage is not NotSet:
-                config.all_array_storage = all_array_storage
+                config.all_array_storage = all_array_storage  # type: ignore
             if all_array_compression is not NotSet:
-                config.all_array_compression = all_array_compression
+                config.all_array_compression = all_array_compression  # type: ignore
             if compression_kwargs is not NotSet:
-                config.all_array_compression_kwargs = compression_kwargs
+                config.all_array_compression_kwargs = compression_kwargs  # type: ignore
 
             fd = self._fd
 
@@ -968,9 +969,9 @@ class AsdfFile:
     def write_to(
         self,
         fd: PathLike | io.IOBase | GenericFile,
-        all_array_storage: ArrayStorage | NotSet = ...,
-        all_array_compression: Compression | NotSet = ...,
-        compression_kwargs: dict[str, Any] | NotSet = ...,
+        all_array_storage: ArrayStorage | NotSetType = ...,
+        all_array_compression: Compression | NotSetType = ...,
+        compression_kwargs: dict[str, Any] | NotSetType = ...,
         pad_blocks: bool | float = ...,
         include_block_index: bool = ...,
         version: str | None = ...,
@@ -981,9 +982,9 @@ class AsdfFile:
     def write_to(
         self,
         fd: Reader | Writer,
-        all_array_storage: ArrayStorage | NotSet = ...,
-        all_array_compression: Compression | NotSet = ...,
-        compression_kwargs: dict[str, Any] | NotSet = ...,
+        all_array_storage: ArrayStorage | NotSetType = ...,
+        all_array_compression: Compression | NotSetType = ...,
+        compression_kwargs: dict[str, Any] | NotSetType = ...,
         pad_blocks: bool | float = ...,
         include_block_index: bool = ...,
         version: str | None = ...,
@@ -993,9 +994,9 @@ class AsdfFile:
     def write_to(
         self,
         fd: FileLike,
-        all_array_storage: ArrayStorage | NotSet = NotSet,
-        all_array_compression: Compression | NotSet = NotSet,
-        compression_kwargs: dict[str, Any] | NotSet = NotSet,
+        all_array_storage: ArrayStorage | NotSetType = NotSet,
+        all_array_compression: Compression | NotSetType = NotSet,
+        compression_kwargs: dict[str, Any] | NotSetType = NotSet,
         pad_blocks: bool | float = False,
         include_block_index: bool = True,
         version: str | None = None,
@@ -1068,11 +1069,11 @@ class AsdfFile:
         """
         with config_context() as config:
             if all_array_storage is not NotSet:
-                config.all_array_storage = all_array_storage
+                config.all_array_storage = all_array_storage  # type: ignore
             if all_array_compression is not NotSet:
-                config.all_array_compression = all_array_compression
+                config.all_array_compression = all_array_compression  # type: ignore
             if compression_kwargs is not NotSet:
-                config.all_array_compression_kwargs = compression_kwargs
+                config.all_array_compression_kwargs = compression_kwargs  # type: ignore
 
             previous_version = None
             if version is not None:
@@ -1311,9 +1312,9 @@ class AsdfFile:
 
     def search(
         self,
-        key: str | Any | NotSet = NotSet,
-        type_: str | type | NotSet = NotSet,
-        value: str | Any | NotSet = NotSet,
+        key: str | Any | NotSetType = NotSet,
+        type_: str | type | NotSetType = NotSet,
+        value: str | Any | NotSetType = NotSet,
         filter_: FilterFn | None = None,
     ) -> AsdfSearchResult:
         """
@@ -1376,7 +1377,7 @@ def open_asdf(
     ignore_unrecognized_tag: bool = ...,
     _force_raw_types: bool = ...,
     memmap: bool = ...,
-    lazy_tree: bool | NotSet = ...,
+    lazy_tree: bool | NotSetType = ...,
     lazy_load: bool = ...,
     custom_schema: str | None = ...,
     strict_extension_check: bool = ...,
@@ -1393,7 +1394,7 @@ def open_asdf(
     ignore_unrecognized_tag: bool = ...,
     _force_raw_types: bool = ...,
     memmap: bool = ...,
-    lazy_tree: bool | NotSet = ...,
+    lazy_tree: bool | NotSetType = ...,
     lazy_load: bool = ...,
     custom_schema: str | None = ...,
     strict_extension_check: bool = ...,
@@ -1410,7 +1411,7 @@ def open_asdf(
     ignore_unrecognized_tag: bool = False,
     _force_raw_types: bool = False,
     memmap: bool = False,
-    lazy_tree: bool | NotSet = NotSet,
+    lazy_tree: bool | NotSetType = NotSet,
     lazy_load: bool = True,
     custom_schema: str | None = None,
     strict_extension_check: bool = False,

--- a/asdf/_asdf.py
+++ b/asdf/_asdf.py
@@ -28,7 +28,7 @@ from .exceptions import (
 from .extension import Extension, ExtensionProxy, _serialization_context, get_cached_extension_manager
 from .search import AsdfSearchResult
 from .tags.core import AsdfObject, ExtensionMetadata, HistoryEntry, Software
-from .util import NOT_SET
+from .util import NotSet
 
 if TYPE_CHECKING:
     from collections import dict_keys
@@ -51,7 +51,6 @@ if TYPE_CHECKING:
         TreeKey,
     )
 
-    from .util import NotSet
     from .versioning import AsdfVersion
 
 
@@ -826,9 +825,9 @@ class AsdfFile:
 
     def update(
         self,
-        all_array_storage: ArrayStorage | NotSet = NOT_SET,
-        all_array_compression: Compression | NotSet = NOT_SET,
-        compression_kwargs: dict[str, Any] | NotSet = NOT_SET,
+        all_array_storage: ArrayStorage | NotSet = NotSet,
+        all_array_compression: Compression | NotSet = NotSet,
+        compression_kwargs: dict[str, Any] | NotSet = NotSet,
         pad_blocks: bool | float = False,
         include_block_index: bool = True,
         version: str | None = None,
@@ -891,11 +890,11 @@ class AsdfFile:
         """
 
         with config_context() as config:
-            if all_array_storage is not NOT_SET:
+            if all_array_storage is not NotSet:
                 config.all_array_storage = all_array_storage
-            if all_array_compression is not NOT_SET:
+            if all_array_compression is not NotSet:
                 config.all_array_compression = all_array_compression
-            if compression_kwargs is not NOT_SET:
+            if compression_kwargs is not NotSet:
                 config.all_array_compression_kwargs = compression_kwargs
 
             fd = self._fd
@@ -994,9 +993,9 @@ class AsdfFile:
     def write_to(
         self,
         fd: FileLike,
-        all_array_storage: ArrayStorage | NotSet = NOT_SET,
-        all_array_compression: Compression | NotSet = NOT_SET,
-        compression_kwargs: dict[str, Any] | NotSet = NOT_SET,
+        all_array_storage: ArrayStorage | NotSet = NotSet,
+        all_array_compression: Compression | NotSet = NotSet,
+        compression_kwargs: dict[str, Any] | NotSet = NotSet,
         pad_blocks: bool | float = False,
         include_block_index: bool = True,
         version: str | None = None,
@@ -1068,11 +1067,11 @@ class AsdfFile:
             Compute and write block checksums to the file.
         """
         with config_context() as config:
-            if all_array_storage is not NOT_SET:
+            if all_array_storage is not NotSet:
                 config.all_array_storage = all_array_storage
-            if all_array_compression is not NOT_SET:
+            if all_array_compression is not NotSet:
                 config.all_array_compression = all_array_compression
-            if compression_kwargs is not NOT_SET:
+            if compression_kwargs is not NotSet:
                 config.all_array_compression_kwargs = compression_kwargs
 
             previous_version = None
@@ -1312,9 +1311,9 @@ class AsdfFile:
 
     def search(
         self,
-        key: str | Any | NotSet = NOT_SET,
-        type_: str | type | NotSet = NOT_SET,
-        value: str | Any | NotSet = NOT_SET,
+        key: str | Any | NotSet = NotSet,
+        type_: str | type | NotSet = NotSet,
+        value: str | Any | NotSet = NotSet,
         filter_: FilterFn | None = None,
     ) -> AsdfSearchResult:
         """
@@ -1411,7 +1410,7 @@ def open_asdf(
     ignore_unrecognized_tag: bool = False,
     _force_raw_types: bool = False,
     memmap: bool = False,
-    lazy_tree: bool | NotSet = NOT_SET,
+    lazy_tree: bool | NotSet = NotSet,
     lazy_load: bool = True,
     custom_schema: str | None = None,
     strict_extension_check: bool = False,
@@ -1497,7 +1496,7 @@ def open_asdf(
         msg = "'strict_extension_check' and 'ignore_missing_extensions' are incompatible options"
         raise ValueError(msg)
 
-    if lazy_tree is NOT_SET:
+    if lazy_tree is NotSet:
         lazy_tree = get_config().lazy_tree
 
     instance = AsdfFile(

--- a/asdf/_asdf.py
+++ b/asdf/_asdf.py
@@ -28,7 +28,7 @@ from .exceptions import (
 from .extension import Extension, ExtensionProxy, _serialization_context, get_cached_extension_manager
 from .search import AsdfSearchResult
 from .tags.core import AsdfObject, ExtensionMetadata, HistoryEntry, Software
-from .util import NotSet
+from .util import NOT_SET
 
 if TYPE_CHECKING:
     from collections import dict_keys
@@ -826,9 +826,9 @@ class AsdfFile:
 
     def update(
         self,
-        all_array_storage: ArrayStorage | NotSetType = NotSet,
-        all_array_compression: Compression | NotSetType = NotSet,
-        compression_kwargs: dict[str, Any] | NotSetType = NotSet,
+        all_array_storage: ArrayStorage | NotSetType = NOT_SET,
+        all_array_compression: Compression | NotSetType = NOT_SET,
+        compression_kwargs: dict[str, Any] | NotSetType = NOT_SET,
         pad_blocks: bool | float = False,
         include_block_index: bool = True,
         version: str | None = None,
@@ -891,12 +891,12 @@ class AsdfFile:
         """
 
         with config_context() as config:
-            if all_array_storage is not NotSet:
-                config.all_array_storage = typing.cast("ArrayStorage", all_array_storage)
-            if all_array_compression is not NotSet:
-                config.all_array_compression = typing.cast("Compression", all_array_compression)
-            if compression_kwargs is not NotSet:
-                config.all_array_compression_kwargs = typing.cast("dict", compression_kwargs)
+            if all_array_storage is not NOT_SET:
+                config.all_array_storage = all_array_storage
+            if all_array_compression is not NOT_SET:
+                config.all_array_compression = all_array_compression
+            if compression_kwargs is not NOT_SET:
+                config.all_array_compression_kwargs = compression_kwargs
 
             fd = self._fd
 
@@ -994,9 +994,9 @@ class AsdfFile:
     def write_to(
         self,
         fd: FileLike,
-        all_array_storage: ArrayStorage | NotSetType = NotSet,
-        all_array_compression: Compression | NotSetType = NotSet,
-        compression_kwargs: dict[str, Any] | NotSetType = NotSet,
+        all_array_storage: ArrayStorage | NotSetType = NOT_SET,
+        all_array_compression: Compression | NotSetType = NOT_SET,
+        compression_kwargs: dict[str, Any] | NotSetType = NOT_SET,
         pad_blocks: bool | float = False,
         include_block_index: bool = True,
         version: str | None = None,
@@ -1068,12 +1068,12 @@ class AsdfFile:
             Compute and write block checksums to the file.
         """
         with config_context() as config:
-            if all_array_storage is not NotSet:
-                config.all_array_storage = typing.cast("ArrayStorage", all_array_storage)
-            if all_array_compression is not NotSet:
-                config.all_array_compression = typing.cast("Compression", all_array_compression)
-            if compression_kwargs is not NotSet:
-                config.all_array_compression_kwargs = typing.cast("dict", compression_kwargs)
+            if all_array_storage is not NOT_SET:
+                config.all_array_storage = all_array_storage
+            if all_array_compression is not NOT_SET:
+                config.all_array_compression = all_array_compression
+            if compression_kwargs is not NOT_SET:
+                config.all_array_compression_kwargs = compression_kwargs
 
             previous_version = None
             if version is not None:
@@ -1312,9 +1312,9 @@ class AsdfFile:
 
     def search(
         self,
-        key: str | Any | NotSetType = NotSet,
-        type_: str | type | NotSetType = NotSet,
-        value: str | Any | NotSetType = NotSet,
+        key: str | Any | NotSetType = NOT_SET,
+        type_: str | type | NotSetType = NOT_SET,
+        value: str | Any | NotSetType = NOT_SET,
         filter_: FilterFn | None = None,
     ) -> AsdfSearchResult:
         """
@@ -1322,23 +1322,23 @@ class AsdfFile:
 
         Parameters
         ----------
-        key : NotSet, str, or any other object
+        key : NOT_SET, str, or any other object
             Search query that selects nodes by dict key or list index.
-            If NotSet, the node key is unconstrained.
+            If NOT_SET, the node key is unconstrained.
             If str, the input is searched among keys/indexes as a regular
             expression pattern.
             If any other object, node's key or index must equal the queried key.
 
-        type_ : NotSet, str, or builtins.type
+        type_ : NOT_SET, str, or builtins.type
             Search query that selects nodes by type.
-            If NotSet, the node type is unconstrained.
+            If NOT_SET, the node type is unconstrained.
             If str, the input is searched among (fully qualified) node type
             names as a regular expression pattern.
             If builtins.type, the node must be an instance of the input.
 
-        value : NotSet, str, or any other object
+        value : NOT_SET, str, or any other object
             Search query that selects nodes by value.
-            If NotSet, the node value is unconstrained.
+            If NOT_SET, the node value is unconstrained.
             If str, the input is searched among values as a regular
             expression pattern.
             If any other object, node's value must equal the queried value.
@@ -1411,7 +1411,7 @@ def open_asdf(
     ignore_unrecognized_tag: bool = False,
     _force_raw_types: bool = False,
     memmap: bool = False,
-    lazy_tree: bool | NotSetType = NotSet,
+    lazy_tree: bool | NotSetType = NOT_SET,
     lazy_load: bool = True,
     custom_schema: str | None = None,
     strict_extension_check: bool = False,
@@ -1497,7 +1497,7 @@ def open_asdf(
         msg = "'strict_extension_check' and 'ignore_missing_extensions' are incompatible options"
         raise ValueError(msg)
 
-    if lazy_tree is NotSet:
+    if lazy_tree is NOT_SET:
         lazy_tree = get_config().lazy_tree
 
     instance = AsdfFile(

--- a/asdf/_dump.py
+++ b/asdf/_dump.py
@@ -1,7 +1,7 @@
 from io import BytesIO
 
 from asdf._asdf import AsdfFile, open_asdf
-from asdf.util import NotSet
+from asdf.util import NOT_SET
 
 __all__ = ["dump", "dumps", "load", "loads"]
 
@@ -12,9 +12,9 @@ def dump(
     *,
     version=None,
     extensions=None,
-    all_array_storage=NotSet,
-    all_array_compression=NotSet,
-    compression_kwargs=NotSet,
+    all_array_storage=NOT_SET,
+    all_array_compression=NOT_SET,
+    compression_kwargs=NOT_SET,
     pad_blocks=False,
     custom_schema=None,
     write_checksums=True,
@@ -75,9 +75,9 @@ def dumps(
     *,
     version=None,
     extensions=None,
-    all_array_storage=NotSet,
-    all_array_compression=NotSet,
-    compression_kwargs=NotSet,
+    all_array_storage=NOT_SET,
+    all_array_compression=NOT_SET,
+    compression_kwargs=NOT_SET,
     pad_blocks=False,
     custom_schema=None,
     write_checksums=True,

--- a/asdf/_dump.py
+++ b/asdf/_dump.py
@@ -1,7 +1,7 @@
 from io import BytesIO
 
 from asdf._asdf import AsdfFile, open_asdf
-from asdf.util import NOT_SET
+from asdf.util import NotSet
 
 __all__ = ["dump", "dumps", "load", "loads"]
 
@@ -12,9 +12,9 @@ def dump(
     *,
     version=None,
     extensions=None,
-    all_array_storage=NOT_SET,
-    all_array_compression=NOT_SET,
-    compression_kwargs=NOT_SET,
+    all_array_storage=NotSet,
+    all_array_compression=NotSet,
+    compression_kwargs=NotSet,
     pad_blocks=False,
     custom_schema=None,
     write_checksums=True,
@@ -75,9 +75,9 @@ def dumps(
     *,
     version=None,
     extensions=None,
-    all_array_storage=NOT_SET,
-    all_array_compression=NOT_SET,
-    compression_kwargs=NOT_SET,
+    all_array_storage=NotSet,
+    all_array_compression=NotSet,
+    compression_kwargs=NotSet,
     pad_blocks=False,
     custom_schema=None,
     write_checksums=True,

--- a/asdf/_tests/test_util.py
+++ b/asdf/_tests/test_util.py
@@ -9,9 +9,9 @@ from asdf import generic_io, util
 
 
 def test_not_set():
-    assert util.NOT_SET is not None
+    assert util.NotSet is not None
 
-    assert repr(util.NOT_SET) == "NotSet"
+    assert repr(util.NotSet) == "NotSet"
 
 
 class SomeClass:

--- a/asdf/_tests/test_util.py
+++ b/asdf/_tests/test_util.py
@@ -9,9 +9,11 @@ from asdf import generic_io, util
 
 
 def test_not_set():
-    assert util.NotSet is not None
+    assert util.NOT_SET is not None
 
-    assert repr(util.NotSet) == "NotSet"
+    assert repr(util.NOT_SET) == "NotSet"
+
+    assert util.NotSet is util.NOT_SET
 
 
 class SomeClass:

--- a/asdf/search.py
+++ b/asdf/search.py
@@ -10,7 +10,7 @@ import typing
 from ._display import DEFAULT_MAX_COLS, DEFAULT_MAX_ROWS, DEFAULT_SHOW_VALUES, render_tree
 from ._node_info import collect_schema_info
 from .treeutil import get_children, is_container
-from .util import NotSet
+from .util import NOT_SET
 
 __all__ = ["AsdfSearchResult"]
 
@@ -38,45 +38,45 @@ class AsdfSearchResult:
         self._max_cols = max_cols
         self._show_values = show_values
 
-    def format(self, max_rows=NotSet, max_cols=NotSet, show_values=NotSet):
+    def format(self, max_rows=NOT_SET, max_cols=NOT_SET, show_values=NOT_SET):
         """
         Change formatting parameters of the rendered tree.
 
         Parameters
         ----------
-        max_rows : int, tuple, None, or NotSet, optional
+        max_rows : int, tuple, None, or NOT_SET, optional
             Maximum number of lines to print.  Nodes that cannot be
             displayed will be elided with a message.
             If int, constrain total number of displayed lines.
             If tuple, constrain lines per node at the depth corresponding \
                 to the tuple index.
             If None, display all lines.
-            If NotSet, retain existing value.
+            If NOT_SET, retain existing value.
 
-        max_cols : int, None or NotSet, optional
+        max_cols : int, None or NOT_SET, optional
             Maximum length of line to print.  Nodes that cannot
             be fully displayed will be truncated with a message.
             If int, constrain length of displayed lines.
             If None, line length is unconstrained.
-            If NotSet, retain existing value.
+            If NOT_SET, retain existing value.
 
-        show_values : bool or NotSet, optional
+        show_values : bool or NOT_SET, optional
             Set to False to disable display of primitive values in
             the rendered tree.
-            Set to NotSet to retain existign value.
+            Set to NOT_SET to retain existign value.
 
         Returns
         -------
         AsdfSearchResult
             the reformatted search result
         """
-        if max_rows is NotSet:
+        if max_rows is NOT_SET:
             max_rows = self._max_rows
 
-        if max_cols is NotSet:
+        if max_cols is NOT_SET:
             max_cols = self._max_cols
 
-        if show_values is NotSet:
+        if show_values is NOT_SET:
             show_values = self._show_values
 
         return AsdfSearchResult(
@@ -114,29 +114,29 @@ class AsdfSearchResult:
 
         return ".".join([value_type.__module__, value_type.__name__])
 
-    def search(self, key=NotSet, type_=NotSet, value=NotSet, filter_=None):
+    def search(self, key=NOT_SET, type_=NOT_SET, value=NOT_SET, filter_=None):
         """
         Further narrow the search.
 
         Parameters
         ----------
-        key : NotSet, str, or any other object
+        key : NOT_SET, str, or any other object
             Search query that selects nodes by dict key or list index.
-            If NotSet, the node key is unconstrained.
+            If NOT_SET, the node key is unconstrained.
             If str, the input is searched among keys/indexes as a regular
             expression pattern.
             If any other object, node's key or index must equal the queried key.
 
-        type_ : NotSet, str, or builtins.type
+        type_ : NOT_SET, str, or builtins.type
             Search query that selects nodes by type.
-            If NotSet, the node type is unconstrained.
+            If NOT_SET, the node type is unconstrained.
             If str, the input is searched among (fully qualified) node type
             names as a regular expression pattern.
             If builtins.type, the node must be an instance of the input.
 
-        value : NotSet, str, or any other object
+        value : NOT_SET, str, or any other object
             Search query that selects nodes by value.
-            If NotSet, the node value is unconstrained.
+            If NOT_SET, the node value is unconstrained.
             If str, the input is searched among values as a regular
             expression pattern.
             If any other object, node's value must equal the queried value.
@@ -156,8 +156,8 @@ class AsdfSearchResult:
         AsdfSearchResult
             the subsequent search result
         """
-        if not (isinstance(type_, (str, typing.Pattern, builtins.type)) or type_ is NotSet):
-            msg = "type must be NotSet, str, regular expression, or instance of builtins.type"
+        if not (isinstance(type_, (str, typing.Pattern, builtins.type)) or type_ is NOT_SET):
+            msg = "type must be NOT_SET, str, regular expression, or instance of builtins.type"
             raise TypeError(msg)
 
         # value and key arguments can be anything, but pattern and str have special behavior
@@ -173,7 +173,7 @@ class AsdfSearchResult:
                 if key.search(str(identifier)) is None:
                     return False
 
-            elif key is not NotSet and not self._safe_equals(identifier, key):
+            elif key is not NOT_SET and not self._safe_equals(identifier, key):
                 return False
 
             if isinstance(type_, typing.Pattern):
@@ -194,7 +194,7 @@ class AsdfSearchResult:
                 if value.search(str(node)) is None:
                     return False
 
-            elif value is not NotSet and not self._safe_equals(node, value):
+            elif value is not NOT_SET and not self._safe_equals(node, value):
                 return False
 
             if filter_ is not None and not filter_(node, identifier):

--- a/asdf/search.py
+++ b/asdf/search.py
@@ -10,7 +10,7 @@ import typing
 from ._display import DEFAULT_MAX_COLS, DEFAULT_MAX_ROWS, DEFAULT_SHOW_VALUES, render_tree
 from ._node_info import collect_schema_info
 from .treeutil import get_children, is_container
-from .util import NOT_SET
+from .util import NotSet
 
 __all__ = ["AsdfSearchResult"]
 
@@ -38,7 +38,7 @@ class AsdfSearchResult:
         self._max_cols = max_cols
         self._show_values = show_values
 
-    def format(self, max_rows=NOT_SET, max_cols=NOT_SET, show_values=NOT_SET):
+    def format(self, max_rows=NotSet, max_cols=NotSet, show_values=NotSet):
         """
         Change formatting parameters of the rendered tree.
 
@@ -70,13 +70,13 @@ class AsdfSearchResult:
         AsdfSearchResult
             the reformatted search result
         """
-        if max_rows is NOT_SET:
+        if max_rows is NotSet:
             max_rows = self._max_rows
 
-        if max_cols is NOT_SET:
+        if max_cols is NotSet:
             max_cols = self._max_cols
 
-        if show_values is NOT_SET:
+        if show_values is NotSet:
             show_values = self._show_values
 
         return AsdfSearchResult(
@@ -114,7 +114,7 @@ class AsdfSearchResult:
 
         return ".".join([value_type.__module__, value_type.__name__])
 
-    def search(self, key=NOT_SET, type_=NOT_SET, value=NOT_SET, filter_=None):
+    def search(self, key=NotSet, type_=NotSet, value=NotSet, filter_=None):
         """
         Further narrow the search.
 
@@ -156,7 +156,7 @@ class AsdfSearchResult:
         AsdfSearchResult
             the subsequent search result
         """
-        if not (isinstance(type_, (str, typing.Pattern, builtins.type)) or type_ is NOT_SET):
+        if not (isinstance(type_, (str, typing.Pattern, builtins.type)) or type_ is NotSet):
             msg = "type must be NotSet, str, regular expression, or instance of builtins.type"
             raise TypeError(msg)
 
@@ -173,7 +173,7 @@ class AsdfSearchResult:
                 if key.search(str(identifier)) is None:
                     return False
 
-            elif key is not NOT_SET and not self._safe_equals(identifier, key):
+            elif key is not NotSet and not self._safe_equals(identifier, key):
                 return False
 
             if isinstance(type_, typing.Pattern):
@@ -194,7 +194,7 @@ class AsdfSearchResult:
                 if value.search(str(node)) is None:
                     return False
 
-            elif value is not NOT_SET and not self._safe_equals(node, value):
+            elif value is not NotSet and not self._safe_equals(node, value):
                 return False
 
             if filter_ is not None and not filter_(node, identifier):

--- a/asdf/typing.py
+++ b/asdf/typing.py
@@ -11,6 +11,7 @@ import numpy.typing as npt
 from typing_extensions import Reader, Writer
 
 from asdf.generic_io import GenericFile
+from asdf.util import _NOT_SET_TYPE
 from asdf.versioning import AsdfVersion
 
 __all__ = [
@@ -77,3 +78,5 @@ ByteArray1D: TypeAlias = np.ndarray[tuple[int], np.dtype[np.uint8]]
 
 #: A callback that returns a `ByteArray1D`
 BlockDataCallback = Callable[[], ByteArray1D]
+
+NotSetType = Literal[_NOT_SET_TYPE.NOT_SET]

--- a/asdf/typing.py
+++ b/asdf/typing.py
@@ -25,6 +25,7 @@ __all__ = [
     "FileMode",
     "FilterFn",
     "NDArray",
+    "NotSetType",
     "PathLike",
     "Reader",
     "TreeKey",

--- a/asdf/util.py
+++ b/asdf/util.py
@@ -3,7 +3,6 @@ import importlib.util
 import math
 import re
 import struct
-import sys
 from functools import lru_cache
 from typing import Final
 
@@ -11,17 +10,6 @@ import numpy as np
 import yaml
 
 from . import constants
-
-# The standard library importlib.metadata returns duplicate entrypoints
-# for all python versions up to and including 3.11
-# https://github.com/python/importlib_metadata/issues/410#issuecomment-1304258228
-# see PR https://github.com/asdf-format/asdf/pull/1260
-# see issue https://github.com/asdf-format/asdf/issues/1254
-if sys.version_info >= (3, 12):
-    pass
-else:
-    pass
-
 
 # We're importing our own copy of urllib.parse because
 # we need to patch it to support asdf:// URIs, but it'd
@@ -40,6 +28,7 @@ _patched_urllib_parse.uses_netloc.append("asdf")
 
 
 __all__ = [
+    "NOT_SET",
     "FileType",
     "NotSet",
     "calculate_padding",
@@ -283,7 +272,8 @@ class _NOT_SET_TYPE(enum.Enum):
 
 #: Special value indicating that a parameter is not set.
 #: Distinct from None, which may for example be a value of interest in a search.
-NotSet: Final = _NOT_SET_TYPE.NOT_SET
+NOT_SET: Final = _NOT_SET_TYPE.NOT_SET
+NotSet: Final = NOT_SET
 
 
 def uri_match(pattern, uri):

--- a/asdf/util.py
+++ b/asdf/util.py
@@ -5,7 +5,7 @@ import re
 import struct
 import sys
 from functools import lru_cache
-from typing import Final, Literal, TypeAlias
+from typing import Final
 
 import numpy as np
 import yaml
@@ -40,7 +40,6 @@ _patched_urllib_parse.uses_netloc.append("asdf")
 
 
 __all__ = [
-    "NOT_SET",
     "FileType",
     "NotSet",
     "calculate_padding",
@@ -287,10 +286,7 @@ class _NOT_SET_TYPE(enum.Enum):
 
 #: Special value indicating that a parameter is not set.
 #: Distinct from None, which may for example be a value of interest in a search.
-NOT_SET: Final = _NOT_SET_TYPE.NOT_SET
-
-#: Type corresponding to ``NOT_SET`` value for use in type-checking
-NotSet: TypeAlias = Literal[_NOT_SET_TYPE.NOT_SET]
+NotSet: Final = _NOT_SET_TYPE.NOT_SET
 
 
 def uri_match(pattern, uri):

--- a/asdf/util.py
+++ b/asdf/util.py
@@ -281,9 +281,6 @@ class _NOT_SET_TYPE(enum.Enum):
         return str(self.value)
 
 
-# This needs to be all caps because otherwise type-checkers will assume its mutable
-# https://github.com/facebook/pyrefly/issues/3042
-
 #: Special value indicating that a parameter is not set.
 #: Distinct from None, which may for example be a value of interest in a search.
 NotSet: Final = _NOT_SET_TYPE.NOT_SET

--- a/changes/2031.feature.rst
+++ b/changes/2031.feature.rst
@@ -1,3 +1,2 @@
 Added type hints to `AsdfFile` and `asdf.config.AsdfConfig`.
 Added `asdf.typing` module containing new type aliases.
-Renamed ``NotSet`` to `asdf.util.NOT_SET`.


### PR DESCRIPTION
## Description
Fixes https://github.com/asdf-format/asdf/issues/2090

Remove `asdf.util.NOT_SET` (we haven't released a version that contains this) and restore `asdf.util.NotSet`. This retains backwards compatibility.

I was able to reproduce the romancal regtest failure locally and this PR fixes the local failure. Running full regtests with this PR to confirm the fix:
https://github.com/spacetelescope/RegressionTests/actions/runs/28875897376
all passing.

## AI Disclosure
No AI was used.

## Tasks

- [ ] [run `prek` on your machine](https://prek.j178.dev/quickstart/)
- [ ] [run `pytest` on your machine](https://docs.pytest.org/en/7.1.x/getting-started.html)
- [ ] Does this PR add new features and / or change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
    - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
    - [ ] update relevant docstrings and / or `docs/` page
    - [ ] for any new features, add unit tests

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: bug fix
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
