### PR TITLE
fix ci badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,8 +3,8 @@ ASDF - Advanced Scientific Data Format
 
 .. _begin-badges:
 
-.. image:: https://github.com/asdf-format/asdf/workflows/CI/badge.svg
-    :target: https://github.com/asdf-format/asdf/actions
+.. image:: https://github.com/asdf-format/asdf/workflows/ci.yml/badge.svg
+    :target: https://github.com/asdf-format/asdf/actions/workflows/ci.yml
     :alt: CI Status
 
 .. image:: https://readthedocs.org/projects/asdf/badge/?version=latest


### PR DESCRIPTION
## Description
Follow up to https://github.com/asdf-format/asdf/pull/2093. After merging I checked the README and noticed the CI badge was unexpectedly red. On main it's pointing to a non-existent workflow. This PR fixes the badge.

## AI Disclosure
No AI was used.

## Tasks

- [ ] [run `prek` on your machine](https://prek.j178.dev/quickstart/)
- [ ] [run `pytest` on your machine](https://docs.pytest.org/en/7.1.x/getting-started.html)
- [ ] Does this PR add new features and / or change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
    - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
    - [ ] update relevant docstrings and / or `docs/` page
    - [ ] for any new features, add unit tests

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: bug fix
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
