### PR TITLE
Update prek version pins

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
     - id: text-unicode-replacement-char
 
 - repo: https://github.com/codespell-project/codespell
-  rev: v2.4.1
+  rev: v2.4.2
   hooks:
     - id: codespell
       args: ["--write-changes"]
@@ -43,14 +43,14 @@ repos:
       exclude: "asdf/(extern||_jsonschema)/.*"
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: 'v0.15.12'
+  rev: 'v0.15.21'
   hooks:
     - id: ruff-check
       args: ["--fix"]
     - id: ruff-format
 
 - repo: https://github.com/tombi-toml/tombi-pre-commit
-  rev: v0.9.25
+  rev: v1.2.0
   hooks:
     - id: tombi-format
       args: ["--offline"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,14 +46,14 @@ benchmark = ["asdf[tests]", "pytest-benchmark"]
 test = ["asdf[tests]"]
 
 [project.urls]
-'documentation' = "https://asdf.readthedocs.io/en/stable/"
-'repository' = "https://github.com/asdf-format/asdf"
-'tracker' = "https://github.com/asdf-format/asdf/issues"
+"documentation" = "https://asdf.readthedocs.io/en/stable/"
+"repository" = "https://github.com/asdf-format/asdf"
+"tracker" = "https://github.com/asdf-format/asdf/issues"
 
 [project.entry-points]
 asdf_extensions = { builtin = "asdf.extension._legacy:BuiltinExtension" }
-'asdf.extensions' = { asdf = "asdf._core._integration:get_extensions" }
-'asdf.resource_mappings' = { asdf = "asdf._core._integration:get_json_schema_resource_mappings" }
+"asdf.extensions" = { asdf = "asdf._core._integration:get_extensions" }
+"asdf.resource_mappings" = { asdf = "asdf._core._integration:get_json_schema_resource_mappings" }
 
 [project.scripts]
 asdftool = "asdf._commands.main:main"
@@ -67,9 +67,9 @@ include = ["asdf*"]
 exclude = ["asdf/_jsonschema/json/*"]
 
 [tool.setuptools.package-data]
-'asdf.commands.tests.data' = ["*"]
-'asdf.tags.core.tests.data' = ["*"]
-'asdf.tests.data' = ["*"]
+"asdf.commands.tests.data" = ["*"]
+"asdf.tags.core.tests.data" = ["*"]
+"asdf.tests.data" = ["*"]
 
 [tool.setuptools_scm]
 version_file = "asdf/_version.py"


### PR DESCRIPTION
## Description
* Updated prek version pins
* Applied changed formatting to `pyproject.toml`

## AI Disclosure
No AI tools used

## Tasks

- [ ] [run `prek` on your machine](https://prek.j178.dev/quickstart/)
- [ ] [run `pytest` on your machine](https://docs.pytest.org/en/7.1.x/getting-started.html)
- [ ] Does this PR add new features and / or change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
    - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
    - [ ] update relevant docstrings and / or `docs/` page
    - [ ] for any new features, add unit tests

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: bug fix
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
