### PR TITLE
Port type-checking CI job to nox

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,18 +36,6 @@ jobs:
         persist-credentials: false
     - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
     - uses: j178/prek-action@e98a699c41eb69ab013a45817a0406469a748f8d # v2.0.5
-  type-checking:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      with:
-        persist-credentials: false
-    - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
-      with:
-        # Run type checking against the oldest supported version
-        python-version: "3.10"
-    - run: pip install -e ".[all,tests,typing]"
-    - run: pyrefly check --output-format=github
   core-generate-jobs:
     runs-on: ubuntu-latest
     outputs:

--- a/noxfile.py
+++ b/noxfile.py
@@ -397,7 +397,7 @@ def pytestdev(session: Session) -> None:
     Asdf(parallel=True).install(session, "git+https://github.com/pytest-dev/pytest").test(session)
 
 
-@nox.session(tags=["core", "type-checking"], python="3.10")
+@nox.session(name="type-checking", tags=["core", "type-checking"], python="3.10")
 def type_checking(session: Session) -> None:
     # Install asdf with typing dependencies
     Asdf(parallel=False, extras=["all", "tests", "typing"]).install(session)

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from dataclasses import KW_ONLY, dataclass
+import json
+import os
+from dataclasses import KW_ONLY, dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -26,6 +28,17 @@ def log_dependencies(session: Session) -> None:
         session.run_install("uv", "pip", "freeze", silent=True)
     else:
         session.run_install("pip", "freeze", silent=True)
+
+
+def is_ci() -> bool:
+    """Returns `True` if nox is currently running in a CI environment."""
+    ci = os.environ.get("CI", "")
+    try:
+        # Parse as JSON so that `"true"`, `"1"`, etc register as `True`
+        # `"false"`, `"0"`, or any invalid value registers as `False`
+        return bool(json.loads(ci))
+    except json.JSONDecodeError:
+        return False
 
 
 @dataclass(frozen=True)
@@ -69,7 +82,7 @@ class Package:
     def test(self, session: Session) -> None:
         """Run the package's test suite."""
         log_dependencies(session)
-        session.run(*self._generate_pytest_command(), env=self.env)
+        session.run(*self._pytest_args(), *session.posargs, env=self.env)
 
     def _installer_spec(self, dir: Path) -> str:
         """Get the full dependency spec for installing the package which can be passed to pip.
@@ -79,7 +92,7 @@ class Package:
         extras = f"[{','.join(self.extras)}]" if self.extras else ""
         return f"{dir}{extras}"
 
-    def _generate_pytest_command(self):
+    def _pytest_args(self):
         """Get the full pytest command for testing this package.
 
         Returns a generator that yields the pytest command followed by all arguments.
@@ -102,6 +115,7 @@ class Asdf:
 
     parallel: bool
     show_slowest: int | None = 10
+    extras: list[str] = field(default_factory=lambda: ["all", "tests"])
 
     def install(self, session: Session, *extra_deps: str) -> Asdf:
         """Install local version of ASDF and its dependencies.
@@ -111,7 +125,12 @@ class Asdf:
         if self.parallel:
             session.install("pytest-xdist")
 
-        session.install("-e", ".[all,tests]")
+        if self.extras:
+            extras = f"[{','.join(self.extras)}]"
+        else:
+            extras = ""
+
+        session.install("-e", f".{extras}")
 
         if extra_deps:
             session.install(*extra_deps)
@@ -124,7 +143,7 @@ class Asdf:
         Arguments passed to `extra_args` are forwarded to pytest.
         """
         log_dependencies(session)
-        session.run(*self._pytest_args(), *extra_args)
+        session.run(*self._pytest_args(), *extra_args, *session.posargs)
         return self
 
     def install_oldest_deps(self, session: Session) -> Asdf:
@@ -376,3 +395,14 @@ def oldestdeps(session: Session) -> None:
 def pytestdev(session: Session) -> None:
     """Run asdf tests using latest unstable pytest version"""
     Asdf(parallel=True).install(session, "git+https://github.com/pytest-dev/pytest").test(session)
+
+
+@nox.session(tags=["core", "type-checking"], python="3.10")
+def type_checking(session: Session) -> None:
+    # Install asdf with typing dependencies
+    Asdf(parallel=False, extras=["all", "tests", "typing"]).install(session)
+    # If running in CI, set Github output format unless output format is manually set
+    if not any(arg.startswith("--output-format") for arg in session.posargs) and is_ci():
+        session.posargs.append("--output-format=github")
+
+    session.run("pyrefly", "check", *session.posargs)

--- a/noxfile.py
+++ b/noxfile.py
@@ -399,6 +399,8 @@ def pytestdev(session: Session) -> None:
 
 @nox.session(name="type-checking", tags=["core", "type-checking"], python="3.10")
 def type_checking(session: Session) -> None:
+    """Run pyrefly type-checking."""
+
     # Install asdf with typing dependencies
     Asdf(parallel=False, extras=["all", "tests", "typing"]).install(session)
     # If running in CI, set Github output format unless output format is manually set


### PR DESCRIPTION
## Description
- Added new `type-checking` session to `noxfile.py` that runs Pyrefly
- Removed `type-checking` job from `ci.yml` since type-checking is now run as part of the nox matrix

Closes #2108 

## AI Disclosure
No AI tools used

## Tasks

- [ ] [run `prek` on your machine](https://prek.j178.dev/quickstart/)
- [ ] [run `pytest` on your machine](https://docs.pytest.org/en/7.1.x/getting-started.html)
- [ ] Does this PR add new features and / or change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
    - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
    - [ ] update relevant docstrings and / or `docs/` page
    - [ ] for any new features, add unit tests

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: bug fix
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
