### PR TITLE
Add nox session for building documentation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -25,7 +25,8 @@ python:
   install:
     - method: uv
       command: sync
-      groups: docs
+      groups:
+        - docs
       path: .
 
 # No extra formats

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -23,10 +23,10 @@ sphinx:
 
 python:
   install:
-    - method: pip
+    - method: uv
+      command: sync
+      groups: docs
       path: .
-      extra_requirements:
-        - docs
 
 # No extra formats
 formats: []

--- a/noxfile.py
+++ b/noxfile.py
@@ -412,7 +412,11 @@ def type_checking(session: Session) -> None:
 
 @nox.session(tags=["docs"], python="3.14", default=False)
 def docs(session: Session) -> None:
-    """Build sphinx documentation."""
+    """Build sphinx documentation.
+
+    If the environment hasn't changed, you can speed up the build by using nox's `-N` flag
+    to reuse the virtual environment and skip reinstalling dependencies, e.g. `nox -N -s docs`.
+    """
     Asdf(extras=[]).install(session, *nox.project.dependency_groups(PYPROJECT, "docs"))
 
     session.run(

--- a/noxfile.py
+++ b/noxfile.py
@@ -414,8 +414,8 @@ def type_checking(session: Session) -> None:
 def docs(session: Session) -> None:
     """Build sphinx documentation.
 
-    If the environment hasn't changed, you can speed up the build by using nox's `-N` flag
-    to reuse the virtual environment and skip reinstalling dependencies, e.g. `nox -N -s docs`.
+    If the environment hasn't changed, you can speed up the build by using nox's `-R` flag
+    to reuse the virtual environment and skip reinstalling dependencies, e.g. `nox -R -s docs`.
     """
     Asdf(extras=[]).install(session, *nox.project.dependency_groups(PYPROJECT, "docs"))
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -113,7 +113,7 @@ class Package:
 class Asdf:
     """Helper class for managing ASDF installation and testing options."""
 
-    parallel: bool
+    parallel: bool = False
     show_slowest: int | None = 10
     extras: list[str] = field(default_factory=lambda: ["all", "tests"])
 
@@ -402,9 +402,26 @@ def type_checking(session: Session) -> None:
     """Run pyrefly type-checking."""
 
     # Install asdf with typing dependencies
-    Asdf(parallel=False, extras=["all", "tests", "typing"]).install(session)
+    Asdf(extras=["all", "tests", "typing"]).install(session)
     # If running in CI, set Github output format unless output format is manually set
     if not any(arg.startswith("--output-format") for arg in session.posargs) and is_ci():
         session.posargs.append("--output-format=github")
 
     session.run("pyrefly", "check", *session.posargs)
+
+
+@nox.session(tags=["docs"], python="3.14", default=False)
+def docs(session: Session) -> None:
+    """Build sphinx documentation."""
+    Asdf(extras=[]).install(session, *nox.project.dependency_groups(PYPROJECT, "docs"))
+
+    session.run(
+        "sphinx-build",
+        "-E",
+        "-T",
+        "-W",
+        "--keep-going",
+        "docs",
+        "build/html",
+        *session.posargs,
+    )

--- a/noxfile.py
+++ b/noxfile.py
@@ -426,6 +426,6 @@ def docs(session: Session) -> None:
         "-W",
         "--keep-going",
         "docs",
-        "build/html",
+        "docs/_build/html",
         *session.posargs,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,14 +29,6 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 all = ["asdf[lz4]", "asdf[http]"]
-docs = [
-  "sphinx-asdf>=0.2.2",
-  "graphviz",
-  "sphinx-inline-tabs",
-  'tomli; python_version < "3.11"',
-  "towncrier",
-  "furo",
-]
 http = ["fsspec[http]>=2022.8.2"]
 lz4 = ["lz4>=0.10"]
 tests = ["asdf[all]", "psutil", "pytest>=8", "syrupy>=5.1"]
@@ -61,10 +53,22 @@ asdftool = "asdf._commands.main:main"
 [dependency-groups]
 # Used for S3 integration testing
 mocks3 = ["boto", "fsspec", "moto[s3,server]", "s3fs>2023.12.1"]
+docs = [
+  "furo",
+  "graphviz",
+  "sphinx-asdf>=0.2.2",
+  "sphinx-inline-tabs",
+  "towncrier",
+]
 
 [build-system]
 requires = ["setuptools>=60", "setuptools_scm[toml]>=8", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.uv.dependency-groups]
+# In sphinx <9.1 autodoc doesn't work with our documentation
+# sphinx >=9.1 is only available on Python >=3.12
+docs = { requires-python = ">=3.12" }
 
 [tool.setuptools.packages.find]
 include = ["asdf*"]


### PR DESCRIPTION
## Description
- Moved docs dependencies from a package extra to a `docs` dependency group since the docs dependencies shouldn't be visible to downstream packages
- Added minimum python version >= 3.12 for `docs` group. This is only enforced for `uv` currently.
- Added `docs` session to `noxfile.py`
- Updated `.readthedocs.yaml` to use `uv` since RTD doesn't support dependency groups with `pip` (even though pip itself does)

I'd previously mentioned that a problem I had with using tox to build the documentation is that it adds a lot of overhead to local docs builds. 
Now that we're using nox this isn't an issue because you can use nox's `-R` flag to reuse the existing virtual environment and skip re-installing dependencies, so there is essentially no overhead to using nox vs building directly.

Closes #2035 (in my opinion)

## AI Disclosure
No AI tools used

## Tasks

- [ ] [run `prek` on your machine](https://prek.j178.dev/quickstart/)
- [ ] [run `pytest` on your machine](https://docs.pytest.org/en/7.1.x/getting-started.html)
- [ ] Does this PR add new features and / or change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
    - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
    - [ ] update relevant docstrings and / or `docs/` page
    - [ ] for any new features, add unit tests

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: bug fix
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
