### PR TITLE
Upgrade ruff to v0.16.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
       exclude: "asdf/(extern||_jsonschema)/.*"
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: 'v0.15.21'
+  rev: 'v0.16.0'
   hooks:
     - id: ruff-check
       args: ["--fix"]

--- a/asdf/_asdf.py
+++ b/asdf/_asdf.py
@@ -360,7 +360,7 @@ class AsdfFile:
         return [e for e in get_config().extensions if self.version_string in e.asdf_standard_requirement]
 
     def _process_user_extensions(
-        self, extensions: None | ExtensionLike | Sequence[ExtensionLike]
+        self, extensions: ExtensionLike | Sequence[ExtensionLike] | None
     ) -> list[ExtensionProxy]:
         """
         Validate a list of extensions requested by the user

--- a/asdf/tags/core/ndarray.py
+++ b/asdf/tags/core/ndarray.py
@@ -241,7 +241,7 @@ def numpy_array_to_list(array):
     return ascii_to_unicode(tolist(array))
 
 
-def inline_array_relax_empty_shape(array: NDArray, shape: None | tuple[int | str, ...]) -> NDArray:
+def inline_array_relax_empty_shape(array: NDArray, shape: tuple[int | str, ...] | None) -> NDArray:
     if shape is None or any(isinstance(s, str) for s in shape):
         return array
 


### PR DESCRIPTION
## Description
- Updated ruff pin in prek to `v0.16.0`
- Fixed new linter warning

The change to the code is just reordering a few type hints, so shouldn't need a changelog entry. 

## AI Disclosure
No AI tools used

## Tasks

- [ ] [run `prek` on your machine](https://prek.j178.dev/quickstart/)
- [ ] [run `pytest` on your machine](https://docs.pytest.org/en/7.1.x/getting-started.html)
- [ ] Does this PR add new features and / or change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
    - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
    - [ ] update relevant docstrings and / or `docs/` page
    - [ ] for any new features, add unit tests

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: bug fix
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>
